### PR TITLE
Add functionality for the presentation helper `replace_word`

### DIFF
--- a/docs/source/presentations/present-helpers.rst
+++ b/docs/source/presentations/present-helpers.rst
@@ -352,7 +352,7 @@ Full API
 
    :returns: None
 
-.. py:function:: longest_common_subword(p: Presentation) -> None
+.. py:function:: longest_common_subword(p: Presentation) -> Union[str, List[int]]
 
    Return the longest common subword of the rules.
 
@@ -365,9 +365,9 @@ Full API
    :param p: the presentation
    :type p: Presentation
 
-   :returns: None
+   :returns: str or List[int]
 
-.. py:function:: replace_subword(p: Presentation, existing: Union[str, List[int]], replacement: Union[str, List[int]])
+.. py:function:: replace_subword(p: Presentation, existing: Union[str, List[int]], replacement: Union[str, List[int]]) -> None
    :noindex:
 
    Replace non-overlapping instances of a subword by another word.
@@ -387,7 +387,7 @@ Full API
 
    :raises RuntimeError: if ``existing`` is empty.
 
-.. py:function:: replace_subword(p: Presentation, w: Union[str, List[int]])
+.. py:function:: replace_subword(p: Presentation, w: Union[str, List[int]]) -> None
 
    Replace non-overlapping instances of a subword.
 
@@ -400,6 +400,8 @@ Full API
    :type p: Presentation
    :param w: the word to be replaced by a new generator
    :type w: str or List[int]
+
+   :returns: None
 
    **Example**::
 
@@ -416,7 +418,7 @@ Full API
 
    If ``existing`` and ``replacement`` are words, then this function replaces
    every instance of ``existing`` in every rule of the form
-   ``existing`` \f$= w\f$ or \f$w = \f$ ``existing``, with the word
+   ``existing`` :math:`= w` or :math:`w =` ``existing``, with the word
    ``replacement``. The presentation ``p`` is changed in-place.
 
    :param p: the presentation
@@ -428,14 +430,14 @@ Full API
 
    :returns: None
 
-.. py:function:: length(p: Presentation) -> None
+.. py:function:: length(p: Presentation) -> int
 
    Return the sum of the lengths of the rules.
 
    :param p: the presentation
    :type p: Presentation
 
-   :returns: None
+   :returns: int
 
 .. py:function:: reverse(p: Presentation) -> None
 

--- a/docs/source/presentations/present-helpers.rst
+++ b/docs/source/presentations/present-helpers.rst
@@ -64,6 +64,9 @@ Contents
    * - :py:func:`replace_subword`
      - Replace non-overlapping instances of a subword.
 
+   * - :py:func:`replace_word`
+     - Replace instances of a word occupying either side of a rule.
+
    * - :py:func:`length`
      - Return the sum of the lengths of the rules.
 
@@ -406,6 +409,24 @@ Full API
       p.rules  # [[1, 0, 0, 1, 0], [0, 1, 0, 0, 1]]
       presentation.replace_subword(p, [0, 0, 1])
       p.rules  # [[1, 2, 0], [0, 1, 2], [2], [0, 0, 1]]
+
+.. py:function:: replace_word(p: Presentation, existing: Union[str, List[int]], replacement: Union[str, List[int]]) -> None
+
+   Replace instances of a word occupying either side of a rule.
+
+   If ``existing`` and ``replacement`` are words, then this function replaces
+   every instance of ``existing`` in every rule of the form
+   ``existing`` \f$= w\f$ or \f$w = \f$ ``existing``, with the word
+   ``replacement``. The presentation ``p`` is changed in-place.
+
+   :param p: the presentation
+   :type p: Presentation
+   :param existing: the word to be replaced
+   :type existing: str or List[int]
+   :param replacement: the replacement word
+   :type replacement: str or List[int]
+
+   :returns: None
 
 .. py:function:: length(p: Presentation) -> None
 

--- a/libsemigroups_pybind11/presentation.py
+++ b/libsemigroups_pybind11/presentation.py
@@ -29,6 +29,7 @@ from _libsemigroups_pybind11 import (
     sort_rules,
     longest_common_subword,
     replace_subword,
+    replace_word,
     length,
     reverse,
     normalize_alphabet,

--- a/libsemigroups_pybind11/tools.py
+++ b/libsemigroups_pybind11/tools.py
@@ -25,7 +25,7 @@ def minimum_libsemigroups_version():
     Returns the minimum required version of libsemigroups required to make
     this work.
     """
-    return "2.3.2"
+    return "2.4.0"
 
 
 if PKGCONFIG_IMPORTED:

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -111,6 +111,7 @@ namespace libsemigroups {
           [](Presentation<T>& p, T const& existing, T const& replace) -> void {
             presentation::replace_subword(p, existing, replace);
           });
+      m.def("replace_word", &presentation::replace_word<T>);
       m.def("length", &presentation::length<T>);
       m.def("reverse", &presentation::reverse<T>);
       m.def("normalize_alphabet", &presentation::normalize_alphabet<T>);

--- a/tests/test_present.py
+++ b/tests/test_present.py
@@ -720,3 +720,14 @@ def test_helpers_remove_redundant_generators():
     p.rules = p.rules + [[1, 1, 1], [0]]
     presentation.remove_redundant_generators(p)
     assert p.rules == [[1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1]]
+
+
+def test_helpers_replace_word():
+    p = Presentation([])
+    presentation.add_rule(p, [0, 0, 0, 0, 0], [])
+    p.alphabet_from_rules()
+    p.validate()
+
+    presentation.replace_word(p, [], [1])
+    p.alphabet_from_rules()
+    p.validate()


### PR DESCRIPTION
This PR adds functionality for the presentation helper function `replace_word`. In addition, some mistakes/omissions in the existing presentation helpers documentation are corrected.