### PR TITLE
Add functionality for the `fpsemi-examples` presentations

### DIFF
--- a/docs/source/api/fpsemi-examples.rst
+++ b/docs/source/api/fpsemi-examples.rst
@@ -13,8 +13,8 @@ This page contains the documentation for examples of finitely presented semigrou
 
    The values in this enum class are used to specify the authors of a
    presentation. Where there are different presentations by different
-   authors, values of this type can be passed as an argument to disambiguate
-   which presentation is wanted.
+   authors, values of this type can be passed as an argument to the functions
+   described on this page to disambiguate which presentation is wanted.
 
    The author values can be combined via the operator ``+``.
 
@@ -97,7 +97,6 @@ Full API
    * ``author.Carmichael`` (given in comment 9.5.2 of `10.1007/978-1-84800-281-4`_)
    * ``author.Coxeter + author.Moser`` (see Ch. 3, Prop 1.2 of `hdl.handle.net/10023/2821`_)
    * ``author.Moore`` (given in comment 9.5.3 of `10.1007/978-1-84800-281-4`_)
-
   
    The default for ``val`` is ``author.Carmichael``.
   
@@ -108,8 +107,8 @@ Full API
   
    :returns: List[Tuple[List[int], List[int]]]
 
-   :raises RuntimeError: if ``val`` is not listed above (modulo order of author)
    :raises RuntimeError: if ``n < 4``
+   :raises RuntimeError: if ``val`` is not one of the combinations of authors listed above (modulo order of author)
 
    .. _10.1017/CBO9781139237253: https://doi.org/10.1017/CBO9781139237253
    .. _10.1007/978-1-84800-281-4: https://doi.org/10.1007/978-1-84800-281-4
@@ -134,8 +133,8 @@ Full API
    
    :returns: List[Tuple[List[int], List[int]]]
 
-   :raises RuntimeError: if ``val`` is not listed above (modulo order of author)
    :raises RuntimeError: if ``n < 4``
+   :raises RuntimeError: if ``val`` is not one of the combinations of authors listed above (modulo order of author) 
    
    .. _hdl.handle.net/10023/2821: http://hdl.handle.net/10023/2821
 
@@ -158,9 +157,9 @@ Full API
    :type val: author
    
    :returns: List[Tuple[List[int], List[int]]]
-   
-   :raises RuntimeError: if ``val`` is not listed above (modulo order of author)
-   :raises RuntimeError: if ``n < 4``
+
+   :raises RuntimeError: if ``n < 4`` 
+   :raises RuntimeError: if ``val`` is not one of the combinations of authors listed above (modulo order of author) 
    
    .. _hdl.handle.net/10023/2821: http://hdl.handle.net/10023/2821
    .. _10.1007/978-1-84800-281-4: https://doi.org/10.1007/978-1-84800-281-4
@@ -184,9 +183,9 @@ Full API
    :type val: author
   
    :returns: List[Tuple[List[int], List[int]]]
-  
-   :raises RuntimeError: if ``val`` is not listed above (modulo order of author)
-   :raises RuntimeError: if ``n < 4``
+ 
+   :raises RuntimeError: if ``n < 4`` 
+   :raises RuntimeError: if ``val`` is not one of the combinations of authors listed above (modulo order of author) 
   
    .. _10.1007/978-1-84800-281-4: https://doi.org/10.1007/978-1-84800-281-4
 
@@ -208,9 +207,9 @@ Full API
    :type val: author
   
    :returns: List[Tuple[List[int], List[int]]]
-  
-   :raises RuntimeError: if ``val`` is not listed above (modulo order of author)
-   :raises RuntimeError: if ``n < 4``
+ 
+   :raises RuntimeError: if ``n < 4`` 
+   :raises RuntimeError: if ``val`` is not one of the combinations of authors listed above (modulo order of author) 
   
    .. _10.1007/978-1-84800-281-4: https://doi.org/10.1007/978-1-84800-281-4
 
@@ -232,9 +231,9 @@ Full API
    :type val: author
   
    :returns: List[Tuple[List[int], List[int]]]
-  
-   :raises RuntimeError: if ``val`` is not ``author.Easdown + author.East + author.FitzGerald``
-   :raises RuntimeError: if ``n < 3``
+
+   :raises RuntimeError: if ``n < 3`` 
+   :raises RuntimeError: if ``val`` is not one of the combinations of authors listed above (modulo order of author) 
 
    .. _10.48550/arxiv.0707.2439: https://doi.org/10.48550/arxiv.0707.2439
   
@@ -257,9 +256,9 @@ Full API
    :type val: author
   
    :returns: List[Tuple[List[int], List[int]]]
-  
-   :raises RuntimeError: if ``val`` is not ``author.FitzGerald``
-   :raises RuntimeError: if ``n < 3``
+ 
+   :raises RuntimeError: if ``n < 3`` 
+   :raises RuntimeError: if ``val`` is not one of the combinations of authors listed above (modulo order of author) 
 
    .. _10.1017/s0004972700037692: https://doi.org/10.1017/s0004972700037692
 
@@ -283,8 +282,9 @@ Full API
   
    :returns: List[Tuple[List[int], List[int]]]
   
-   :raises RuntimeError: if ``val = author.East and n < 4``
-   :raises RuntimeError: if ``val = author.Machine and n != 3``
+   :raises RuntimeError: if ``n < 4`` and ``val = author.East``
+   :raises RuntimeError: if ``n != 3`` and ``val = author.Machine``
+   :raises RuntimeError: if ``val`` is not one of the combinations of authors listed above (modulo order of author)
 
    .. _10.1016/j.jalgebra.2011.04.008: https://doi.org/10.1016/j.jalgebra.2011.04.008
 

--- a/docs/source/api/fpsemi-examples.rst
+++ b/docs/source/api/fpsemi-examples.rst
@@ -1,0 +1,497 @@
+.. Copyright (c) 2022 M. T. Whyte
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+Examples
+========
+
+This page contains the documentation for examples of finitely presented semigroups.
+
+.. py:class:: author
+
+   The values in this enum class are used to specify the authors of a
+   presentation. Where there are different presentations by different
+   authors, values of this type can be passed as an argument to disambiguate
+   which presentation is wanted.
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - :py:func:`symmetric_group`
+     - A presentation for the symmetric group.
+
+   * - :py:func:`alternating_group`
+     - A presentation for the alternating group.
+
+   * - :py:func:`full_transformation_monoid`
+     - A presentation for the full transformation monoid.
+
+   * - :py:func:`partial_transformation_monoid`
+     - A presentation for the partial transformation monoid.
+
+   * - :py:func:`symmetric_inverse_monoid`
+     - A presentation for the symmetric inverse monoid.
+
+   * - :py:func:`dual_symmetric_inverse_monoid`
+     - A presentation for the dual symmetric inverse monoid.
+
+   * - :py:func:`uniform_block_bijection_monoid`
+     - A presentation for the uniform block bijection monoid.
+
+   * - :py:func:`partition_monoid`
+     - A presentation for the partition monoid.
+
+   * - :py:func:`brauer_monoid`
+     - A presentation for the Brauer monoid.
+
+   * - :py:func:`rectangular_band`
+     - A presentation for a rectangular band.
+
+   * - :py:func:`stellar_monoid`
+     - A presentation for the stellar monoid.
+
+   * - :py:func:`chinese_monoid`
+     - A presentation for the Chinese monoid.
+
+   * - :py:func:`monogenic_semigroup`
+     - A presentation for a monogenic semigroup.
+
+   * - :py:func:`plactic_monoid`
+     - A presentation for the plactic monoid.
+
+   * - :py:func:`stylic_monoid`
+     - A presentation for the stylic monoid.
+
+   * - :py:func:`fibonacci_semigroup`
+     - A presentation for a Fibonacci semigroup.
+
+   * - :py:func:`temperley_lieb_monoid`
+     - A presentation for the Temperley-Lieb monoid.
+
+   * - :py:func:`singular_brauer_monoid`
+     - A presentation for the singular part of the Brauer monoid.
+
+   * - :py:func:`orientation_preserving_monoid`
+     - A presentation for the monoid of orientation preserving mappings.
+
+   * - :py:func:`orientation_reversing_monoid`
+     - A presentation for the monoid of orientation reversing mappings.
+
+Full API
+--------
+
+.. py:function:: symmetric_group(n: int, val: author = author.Carmichael) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the symmetric group.
+  
+   Returns a list giving a monoid presentation for the
+   symmetric group. The argument ``val`` determines the specific presentation
+   which is returned. The options are:
+
+   * ``author.Burnside + author.Miller`` (given on p.464 of `10.1017/CBO9781139237253`_)
+   * ``author.Carmichael`` (given in comment 9.5.2 of `10.1007/978-1-84800-281-4`_)
+   * ``author.Coxeter + author.Moser`` (see Ch. 3, Prop 1.2 of `hdl.handle.net/10023/2821`_)
+   * ``author.Moore`` (given in comment 9.5.3 of `10.1007/978-1-84800-281-4`_)
+
+  
+   The default for ``val`` is ``author.Carmichael``.
+  
+   :param n: the degree
+   :type n: int
+   :param val: the author
+   :type val: author
+  
+   :returns: List[Tuple[List[int], List[int]]]
+
+   :raises RuntimeError: if ``val`` is not listed above (modulo order of author)
+   :raises RuntimeError: if ``n < 4``
+
+   .. _10.1017/CBO9781139237253: https://doi.org/10.1017/CBO9781139237253
+   .. _10.1007/978-1-84800-281-4: https://doi.org/10.1007/978-1-84800-281-4
+   .. _hdl.handle.net/10023/2821: http://hdl.handle.net/10023/2821   
+
+.. py:function:: alternating_group(n: int, val: author) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the alternating group.
+   
+   Returns a list giving a monoid presentation defining the
+   alternating group of degree ``n``. The argument ``val`` determines the
+   specific presentation which is returned. The options are:
+
+   * ``author.Moore`` (see Ch. 3, Prop 1.3 of `hdl.handle.net/10023/2821`_)
+   
+   The default for ``val`` is ``author.Moore``.
+   
+   :param n: the degree
+   :type n: int
+   :param val: the author
+   :type val: author
+   
+   :returns: List[Tuple[List[int], List[int]]]
+
+   :raises RuntimeError: if ``val`` is not listed above (modulo order of author)
+   :raises RuntimeError: if ``n < 4``
+   
+   .. _hdl.handle.net/10023/2821: http://hdl.handle.net/10023/2821
+
+.. py:function:: full_transformation_monoid(n: int, val: author) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the full transformation monoid.
+   
+   Returns a list giving a monoid presentation defining the
+   full transformation monoid. The argument ``val`` determines the specific
+   presentation which is returned. The options are:
+
+   * ``author.Aizenstat`` (see Ch. 3, Prop 1.7 of `hdl.handle.net/10023/2821`_)
+   * ``author.Iwahori`` (see Theorem 9.3.1 of `10.1007/978-1-84800-281-4`_)
+   
+   The default for ``val`` is ``author.Iwahori``.
+   
+   :param n: the degree
+   :type n: int
+   :param val: the author
+   :type val: author
+   
+   :returns: List[Tuple[List[int], List[int]]]
+   
+   :raises RuntimeError: if ``val`` is not listed above (modulo order of author)
+   :raises RuntimeError: if ``n < 4``
+   
+   .. _hdl.handle.net/10023/2821: http://hdl.handle.net/10023/2821
+   .. _10.1007/978-1-84800-281-4: https://doi.org/10.1007/978-1-84800-281-4
+
+.. py:function:: partial_transformation_monoid(n: int, val: author) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the partial transformation monoid.
+  
+   Returns a list giving a monoid presentation defining the
+   partial transformation monoid. The argument ``val`` determines the
+   specific presentation which is returned. The options are:
+
+   * ``author.Machine``
+   * ``author.Sutov`` (see Theorem 9.4.1 of `10.1007/978-1-84800-281-4`_)
+  
+   The default for ``val`` is ``author.Sutov``.
+  
+   :param n: the degree
+   :type n: int
+   :param val: the author
+   :type val: author
+  
+   :returns: List[Tuple[List[int], List[int]]]
+  
+   :raises RuntimeError: if ``val`` is not listed above (modulo order of author)
+   :raises RuntimeError: if ``n < 4``
+  
+   .. _10.1007/978-1-84800-281-4: https://doi.org/10.1007/978-1-84800-281-4
+
+.. py:function:: symmetric_inverse_monoid(n: int, val: author) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the symmetric inverse monoid.
+   
+   Returns a list giving a monoid presentation defining the
+   symmetric inverse monoid. The argument ``val`` determines the specific
+   presentation which is returned. The options are:
+
+   * ``author.Sutov`` (see Theorem 9.2.2 of `10.1007/978-1-84800-281-4`_)
+   
+   The default for ``val`` is the only option above.
+  
+   :param n: the degree
+   :type n: int
+   :param val: the author
+   :type val: author
+  
+   :returns: List[Tuple[List[int], List[int]]]
+  
+   :raises RuntimeError: if ``val`` is not listed above (modulo order of author)
+   :raises RuntimeError: if ``n < 4``
+  
+   .. _10.1007/978-1-84800-281-4: https://doi.org/10.1007/978-1-84800-281-4
+
+.. py:function:: dual_symmetric_inverse_monoid(n: int, val: author) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the dual symmetric inverse monoid.
+  
+   Returns a list giving a semigroup presentation defining
+   the dual symmetric inverse monoid of degree ``n``. The argument ``val``
+   determines the specific presentation which is returned. The options are:
+
+   * ``author.Easdown + author.East + author.FitzGerald`` (from Section 3 of `10.48550/arxiv.0707.2439`_)
+
+   The default for ``val`` is the only option above.
+  
+   :param n: the degree
+   :type n: int
+   :param val: the author
+   :type val: author
+  
+   :returns: List[Tuple[List[int], List[int]]]
+  
+   :raises RuntimeError: if ``val`` is not ``author.Easdown + author.East + author.FitzGerald``
+   :raises RuntimeError: if ``n < 3``
+
+   .. _10.48550/arxiv.0707.2439: https://doi.org/10.48550/arxiv.0707.2439
+  
+.. py:function:: uniform_block_bijection_monoid(n: int, val: author) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the uniform block bijection monoid.
+  
+   Returns a list giving a semigroup presentation defining
+   the uniform block bijection monoid of degree ``n``. The argument ``val``
+   determines the specific presentation which is returned. The only option
+   is:
+
+   * ``author.FitzGerald`` (see `10.1017/s0004972700037692`_)
+
+   The default for ``val`` is the only option above.
+  
+   :param n: the degree
+   :type n: int
+   :param val: the author
+   :type val: author
+  
+   :returns: List[Tuple[List[int], List[int]]]
+  
+   :raises RuntimeError: if ``val`` is not ``author.FitzGerald``
+   :raises RuntimeError: if ``n < 3``
+
+   .. _10.1017/s0004972700037692: https://doi.org/10.1017/s0004972700037692
+
+.. py:function:: partition_monoid(n: int, val: author) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the partition monoid.
+  
+   Returns a list giving a semigroup presentation defining
+   the partition monoid of degree ``n``. The argument ``val`` determines the
+   specific presentation which is returned. The options are:
+
+   * ``author.Machine``
+   * ``author.East`` (see Theorem 41 of `10.1016/j.jalgebra.2011.04.008`_)
+  
+   The default for ``val`` is ``author.East``.
+  
+   :param n: the degree
+   :type n: int
+   :param val: the author
+   :type val: author
+  
+   :returns: List[Tuple[List[int], List[int]]]
+  
+   :raises RuntimeError: if ``val = author.East and n < 4``
+   :raises RuntimeError: if ``val = author.Machine and n != 3``
+
+   .. _10.1016/j.jalgebra.2011.04.008: https://doi.org/10.1016/j.jalgebra.2011.04.008
+
+.. py:function:: brauer_monoid(n: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the Brauer monoid.
+  
+   Returns a list giving a semigroup presentation defining
+   the Brauer monoid of degree ``n``, as described in Theorem 3.1 of the
+   paper `10.2478/s11533-006-0017-6`_.
+  
+   :param n: the degree
+   :type n: int
+
+   :returns: List[Tuple[List[int], List[int]]]
+  
+   .. _`10.2478/s11533-006-0017-6`: https://doi.org/10.2478/s11533-006-0017-6
+
+.. py:function:: rectangular_band(m: int, n: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for a rectangular band.
+  
+   Returns a list giving a semigroup presentation defining
+   the `m` by `n` rectangular band, as given in Proposition 4.2 of
+   `10.1007/s002339910016`_.
+  
+
+   :param m: the number of rows
+   :type m: int
+   :param n: the number of columns
+   :type n: int
+
+   :returns: List[Tuple[List[int], List[int]]]
+
+   :raises RuntimeError: if ``m = 0``
+   :raises RuntimeError: if ``n = 0``
+  
+   .. _`10.1007/s002339910016`: https://doi.org/10.1007/s002339910016
+
+.. py:function:: stellar_monoid(l: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the stellar monoid.
+   
+   Returns a list giving a semigroup presentation defining
+   the stellar monoid with ``l`` generators, as in Theorem 4.39 of
+   `10.48550/arXiv.1910.11740`_.
+   
+   :param l: the number of generators
+   :type l: int
+   
+   :returns: List[Tuple[List[int], List[int]]
+
+   :raises RuntimeError: if ``l < 2``
+   
+   .. _`10.48550/arXiv.1910.11740`: https://doi.org/10.48550/arXiv.1910.11740
+
+.. py:function:: chinese_monoid(l: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the Chinese monoid.
+  
+   Returns a list giving a semigroup presentation defining
+   the Chinese monoid with ``n`` generators, as described in `10.1142/S0218196701000425`_.
+   
+   :param n: the number of generators
+   :type n: int
+   
+   :returns: List[Tuple[List[int], List[int]]
+
+   :raises RuntimeError: if ``n < 2``
+   
+   .. _`10.1142/S0218196701000425`: https://doi.org/10.1142/S0218196701000425 
+
+.. py:function:: monogenic_semigroup(m: int, r: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for a monogenic semigroup.
+  
+   Returns a list giving a semigroup presentation defining
+   the monogenic semigroup defined by the presentation
+   :math:`\langle a \mid a^{m + r} = a^m \rangle`.
+
+   :param m: the index
+   :type m: int
+   :param r: the period
+   :type r: int
+
+   :returns: List[Tuple[List[int], List[int]]]
+
+   :raises RuntimeError: if ``r = 0``
+
+.. py:function:: plactic_monoid(n: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the plactic monoid.
+   
+   Returns a list giving a semigroup presentation defining
+   the plactic monoid with ``n`` generators (see Section 3 of
+   `10.1007/s00233-022-10285-3`_).
+
+   :param n: the number of generators
+   :type n: int
+
+   :returns: List[Tuple[List[int], List[int]]]
+
+   :raises RuntimeError: if ``n < 2``
+
+   .. _`10.1007/s00233-022-10285-3`: https://doi.org/10.1007/s00233-022-10285-3
+
+.. py:function:: stylic_monoid(n: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the stylic monoid.
+   
+   Returns a list giving a semigroup presentation defining
+   the stylic monoid with `n` generators (see Theorem 8.1 of
+   `10.1007/s00233-022-10285-3`_).
+
+   :param n: the number of generators
+   :type n: int
+
+   :returns: List[Tuple[List[int], List[int]]]
+
+   :raises RuntimeError: if ``n < 2``
+
+   .. _`10.1007/s00233-022-10285-3`: https://doi.org/10.1007/s00233-022-10285-3
+
+.. py:function:: fibonacci_semigroup(r: int, n: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for a Fibonacci semigroup.
+  
+   Returns a list giving a semigroup presentation defining
+   the Fibonacci semigroup :math:`F(r, n)`, as described in the paper
+   `10.1016/0022-4049(94)90005-1`_.
+  
+   :param r: the length of the left hand sides of the relations
+   :type r: int
+   :param n: the number of generators
+   :type n: int
+  
+   :returns: List[Tuple[List[int], List[int]]]
+  
+   :raises RuntimeError: if ``n = 0``
+   :raises RuntimeError: if ``r = 0``
+  
+   .. _`10.1016/0022-4049(94)90005-1`: https://doi.org/10.1016/0022-4049(94)90005-1
+
+.. py:function:: temperley_lieb_monoid(n: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the Temperley-Lieb monoid.
+   
+   Returns a list giving a semigroup presentation defining
+   the Temperley-Lieb monoid with ``n`` generators, as described in
+   Theorem 2.2 of the paper `10.1093/qmath/haab001`_.
+
+   :param n: the number of generators
+   :type n: int
+
+   :returns: List[Tuple[List[int], List[int]]]
+
+   :raises RuntimeError: if ``n < 3``
+
+   .. _10.1093/qmath/haab001: https://doi.org/10.1093/qmath/haab001
+
+.. py:function:: singular_brauer_monoid(n: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the singular part of the Brauer monoid.
+  
+   Returns a list giving a semigroup presentation for the
+   singular part of the Brauer monoid of degree ``n``, as in Theorem 5 of
+   the paper `10.21136/MB.2007.134125`_).
+
+   :param n: the degree
+   :type n: int
+
+   :returns: List[Tuple[List[int], List[int]]]
+
+   :raises RuntimeError: if ``n < 3``
+
+   .. _`10.21136/MB.2007.134125`: https://doi.org/10.21136/MB.2007.134125
+
+.. py:function:: orientation_preserving_monoid(n: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the monoid of orientation preserving
+   mappings.
+   
+   Returns a list giving a semigroup presentation defining
+   the monoid of orientation preserving mappings on a finite chain of order
+   ``n``, as described in the paper `10.1007/s10012-000-0001-1`_.
+
+   :param n: the order of the chain
+   :type n: int
+
+   :returns: List[Tuple[List[int], List[int]]]
+
+   :raises RuntimeError: if ``n < 3``
+
+   .. _`10.1007/s10012-000-0001-1`: https://doi.org/10.1007/s10012-000-0001-1`
+
+.. py:function:: orientation_reversing_monoid(n: int) -> List[Tuple[List[int], List[int]]])
+
+   A presentation for the monoid of orientation preserving
+   mappings.
+   
+   Returns a list giving a semigroup presentation defining
+   the monoid of orientation reversing mappings on a finite chain of order
+   ``n``, as described in the paper `10.1007/s10012-000-0001-1`_.
+
+   :param n: the order of the chain
+   :type n: int
+
+   :returns: List[Tuple[List[int], List[int]]]
+
+   :raises RuntimeError: if ``n < 3``
+
+   .. _`10.1007/s10012-000-0001-1`: https://doi.org/10.1007/s10012-000-0001-1`

--- a/docs/source/api/fpsemi-examples.rst
+++ b/docs/source/api/fpsemi-examples.rst
@@ -16,6 +16,8 @@ This page contains the documentation for examples of finitely presented semigrou
    authors, values of this type can be passed as an argument to disambiguate
    which presentation is wanted.
 
+   The author values can be combined via the operator ``+``.
+
 .. list-table::
    :widths: 50 50
    :header-rows: 0
@@ -306,7 +308,7 @@ Full API
    A presentation for a rectangular band.
   
    Returns a list giving a semigroup presentation defining
-   the `m` by `n` rectangular band, as given in Proposition 4.2 of
+   the ``m`` by ``n`` rectangular band, as given in Proposition 4.2 of
    `10.1007/s002339910016`_.
   
 
@@ -394,7 +396,7 @@ Full API
    A presentation for the stylic monoid.
    
    Returns a list giving a semigroup presentation defining
-   the stylic monoid with `n` generators (see Theorem 8.1 of
+   the stylic monoid with ``n`` generators (see Theorem 8.1 of
    `10.1007/s00233-022-10285-3`_).
 
    :param n: the number of generators

--- a/docs/source/fpsemigroups.rst
+++ b/docs/source/fpsemigroups.rst
@@ -38,3 +38,4 @@ monoids are:
    api/kambites
    api/knuth-bendix
    presentations/index
+   api/fpsemi-examples

--- a/libsemigroups_pybind11/fpsemigroup.py
+++ b/libsemigroups_pybind11/fpsemigroup.py
@@ -14,10 +14,9 @@ the Presentation class from libsemigroups.
 """
 
 from _libsemigroups_pybind11 import (
+    make,
     author,
-    _symmetric_group, # I'll want to change this so the user can't access it.
-    # The same strange error happens with brauer_monoid(author.Sutov)... But this
-    # function doesn't even take an author value at all.
+    symmetric_group,
     alternating_group,
     full_transformation_monoid,
     partial_transformation_monoid,
@@ -40,8 +39,3 @@ from _libsemigroups_pybind11 import (
 )
 
 from _libsemigroups_pybind11 import make_presentation as make
-
-def symmetric_group(n, val = author.Carmichael):
-    if not isinstance(n, int):
-        raise TypeError("the 1st argument must be an int, found ", type(n))
-    return _symmetric_group(n, val)

--- a/libsemigroups_pybind11/fpsemigroup.py
+++ b/libsemigroups_pybind11/fpsemigroup.py
@@ -14,7 +14,6 @@ various examples of presentations for finitely presented semigroups and monoids.
 """
 
 from _libsemigroups_pybind11 import (
-    make,
     author,
     symmetric_group,
     alternating_group,

--- a/libsemigroups_pybind11/fpsemigroup.py
+++ b/libsemigroups_pybind11/fpsemigroup.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2022, M. T. Whyte
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+
+# pylint: disable=no-name-in-module, invalid-name, unused-import, fixme
+
+"""
+This package provides the user-facing python part of libsemigroups_pybind11 for
+the Presentation class from libsemigroups.
+"""
+
+from _libsemigroups_pybind11 import (
+    author,
+    _symmetric_group, # I'll want to change this so the user can't access it.
+    # The same strange error happens with brauer_monoid(author.Sutov)... But this
+    # function doesn't even take an author value at all.
+    alternating_group,
+    full_transformation_monoid,
+    partial_transformation_monoid,
+    symmetric_inverse_monoid,
+    dual_symmetric_inverse_monoid,
+    uniform_block_bijection_monoid,
+    partition_monoid,
+    brauer_monoid,
+    rectangular_band,
+    stellar_monoid,
+    chinese_monoid,
+    monogenic_semigroup,
+    plactic_monoid,
+    stylic_monoid,
+    fibonacci_semigroup,
+    temperley_lieb_monoid,
+    singular_brauer_monoid,
+    orientation_preserving_monoid,
+    orientation_reversing_monoid
+)
+
+from _libsemigroups_pybind11 import make_presentation as make
+
+def symmetric_group(n, val = author.Carmichael):
+    if not isinstance(n, int):
+        raise TypeError("the 1st argument must be an int, found ", type(n))
+    return _symmetric_group(n, val)

--- a/libsemigroups_pybind11/fpsemigroup.py
+++ b/libsemigroups_pybind11/fpsemigroup.py
@@ -10,7 +10,7 @@
 
 """
 This package provides the user-facing python part of libsemigroups_pybind11 for
-the Presentation class from libsemigroups.
+various examples of presentations for finitely presented semigroups and monoids.
 """
 
 from _libsemigroups_pybind11 import (

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -59,38 +59,81 @@ namespace libsemigroups {
         .value("Moore", fpsemigroup::author::Moore)
         .value("Moser", fpsemigroup::author::Moser)
         .value("Sutov", fpsemigroup::author::Sutov)
-        .export_values()
         .def("__add__", &fpsemigroup::operator+);
 
     m.def("make_presentation", &fpsemigroup::make<Presentation<word_type>>)
-        .def("_symmetric_group",
+        .def("symmetric_group",
              &fpsemigroup::symmetric_group,
-             py::arg("n"),
+             py::arg("n").noconvert(),
              py::arg("val") = fpsemigroup::author::Carmichael)
-        .def("alternating_group", &fpsemigroup::alternating_group)
+        .def("alternating_group",
+             &fpsemigroup::alternating_group,
+             py::arg("n").noconvert(),
+             py::arg("val") = fpsemigroup::author::Moore)
         .def("full_transformation_monoid",
-             &fpsemigroup::full_transformation_monoid)
+             &fpsemigroup::full_transformation_monoid,
+             py::arg("n").noconvert(),
+             py::arg("val") = fpsemigroup::author::Iwahori)
         .def("partial_transformation_monoid",
-             &fpsemigroup::partial_transformation_monoid)
-        .def("symmetric_inverse_monoid", &fpsemigroup::symmetric_inverse_monoid)
+             &fpsemigroup::partial_transformation_monoid,
+             py::arg("n").noconvert(),
+             py::arg("val") = fpsemigroup::author::Sutov)
+        .def("symmetric_inverse_monoid",
+             &fpsemigroup::symmetric_inverse_monoid,
+             py::arg("n").noconvert(),
+             py::arg("val") = fpsemigroup::author::Sutov)
         .def("dual_symmetric_inverse_monoid",
-             &fpsemigroup::dual_symmetric_inverse_monoid)
+             &fpsemigroup::dual_symmetric_inverse_monoid,
+             py::arg("n").noconvert(),
+             py::arg("val") = fpsemigroup::author::Easdown
+                              + fpsemigroup::author::East
+                              + fpsemigroup::author::FitzGerald)
         .def("uniform_block_bijection_monoid",
-             &fpsemigroup::uniform_block_bijection_monoid)
-        .def("partition_monoid", &fpsemigroup::partition_monoid)
-        .def("brauer_monoid", &fpsemigroup::brauer_monoid)
-        .def("rectangular_band", &fpsemigroup::rectangular_band)
-        .def("stellar_monoid", &fpsemigroup::stellar_monoid)
-        .def("chinese_monoid", &fpsemigroup::chinese_monoid)
-        .def("monogenic_semigroup", &fpsemigroup::monogenic_semigroup)
-        .def("plactic_monoid", &fpsemigroup::plactic_monoid)
-        .def("stylic_monoid", &fpsemigroup::stylic_monoid)
-        .def("fibonacci_semigroup", &fpsemigroup::fibonacci_semigroup)
-        .def("temperley_lieb_monoid", &fpsemigroup::temperley_lieb_monoid)
-        .def("singular_brauer_monoid", &fpsemigroup::singular_brauer_monoid)
+             &fpsemigroup::uniform_block_bijection_monoid,
+             py::arg("n").noconvert(),
+             py::arg("val") = fpsemigroup::author::FitzGerald)
+        .def("partition_monoid",
+             &fpsemigroup::partition_monoid,
+             py::arg("n").noconvert(),
+             py::arg("val") = fpsemigroup::author::East)
+        .def("brauer_monoid",
+             &fpsemigroup::brauer_monoid,
+             py::arg("n").noconvert())
+        .def("rectangular_band",
+             &fpsemigroup::rectangular_band,
+             py::arg("m").noconvert(),
+             py::arg("n").noconvert())
+        .def("stellar_monoid",
+             &fpsemigroup::stellar_monoid,
+             py::arg("n").noconvert())
+        .def("chinese_monoid",
+             &fpsemigroup::chinese_monoid,
+             py::arg("n").noconvert())
+        .def("monogenic_semigroup",
+             &fpsemigroup::monogenic_semigroup,
+             py::arg("m").noconvert(),
+             py::arg("r").noconvert())
+        .def("plactic_monoid",
+             &fpsemigroup::plactic_monoid,
+             py::arg("n").noconvert())
+        .def("stylic_monoid",
+             &fpsemigroup::stylic_monoid,
+             py::arg("l").noconvert())
+        .def("fibonacci_semigroup",
+             &fpsemigroup::fibonacci_semigroup,
+             py::arg("r").noconvert(),
+             py::arg("n").noconvert())
+        .def("temperley_lieb_monoid",
+             &fpsemigroup::temperley_lieb_monoid,
+             py::arg("n").noconvert())
+        .def("singular_brauer_monoid",
+             &fpsemigroup::singular_brauer_monoid,
+             py::arg("n").noconvert())
         .def("orientation_preserving_monoid",
-             &fpsemigroup::orientation_preserving_monoid)
+             &fpsemigroup::orientation_preserving_monoid,
+             py::arg("n").noconvert())
         .def("orientation_reversing_monoid",
-             &fpsemigroup::orientation_reversing_monoid);
+             &fpsemigroup::orientation_reversing_monoid,
+             py::arg("n").noconvert());
   }
 }  // namespace libsemigroups

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1,0 +1,96 @@
+//
+// libsemigroups_pybind11
+// Copyright (C) 2022 Murray T. Whyte
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// C std headers....
+#include <stddef.h>  // for size_t
+#include <stdint.h>  // for int32_t, uint32_t
+
+// C++ stl headers....
+#include <initializer_list>  // for initializer_list
+#include <vector>            // for vector
+
+// libsemigroups....
+#include <libsemigroups/fpsemi-examples.hpp>  // for monogenic_semigroup, ...
+#include <libsemigroups/present.hpp>          // for Presentation
+#include <libsemigroups/string.hpp>           // for to_string
+#include <libsemigroups/types.hpp>            // for word_type
+
+// pybind11....
+#include <pybind11/pybind11.h>  // for class_, init, module
+#include <pybind11/stl.h>
+
+// libsemigroups_pybind11....
+#include "main.hpp"  // for init_present
+
+namespace py = pybind11;
+namespace libsemigroups {
+  void init_fpsemi_examples(py::module& m) {
+    py::enum_<fpsemigroup::author>(m, "author")
+        .value("Machine", fpsemigroup::author::Machine)
+        .value("Aizenstat", fpsemigroup::author::Aizenstat)
+        .value("Burnside", fpsemigroup::author::Burnside)
+        .value("Carmichael", fpsemigroup::author::Carmichael)
+        .value("Coxeter", fpsemigroup::author::Coxeter)
+        .value("Easdown", fpsemigroup::author::Easdown)
+        .value("East", fpsemigroup::author::East)
+        .value("FitzGerald", fpsemigroup::author::FitzGerald)
+        .value("Godelle", fpsemigroup::author::Godelle)
+        .value("Guralnick", fpsemigroup::author::Guralnick)
+        .value("Iwahori", fpsemigroup::author::Iwahori)
+        .value("Kantor", fpsemigroup::author::Kantor)
+        .value("Kassabov", fpsemigroup::author::Kassabov)
+        .value("Lubotzky", fpsemigroup::author::Lubotzky)
+        .value("Miller", fpsemigroup::author::Miller)
+        .value("Moore", fpsemigroup::author::Moore)
+        .value("Moser", fpsemigroup::author::Moser)
+        .value("Sutov", fpsemigroup::author::Sutov)
+        .export_values()
+        .def("__add__", &fpsemigroup::operator+);
+
+    m.def("make_presentation", &fpsemigroup::make<Presentation<word_type>>)
+        .def("_symmetric_group",
+             &fpsemigroup::symmetric_group,
+             py::arg("n"),
+             py::arg("val") = fpsemigroup::author::Carmichael)
+        .def("alternating_group", &fpsemigroup::alternating_group)
+        .def("full_transformation_monoid",
+             &fpsemigroup::full_transformation_monoid)
+        .def("partial_transformation_monoid",
+             &fpsemigroup::partial_transformation_monoid)
+        .def("symmetric_inverse_monoid", &fpsemigroup::symmetric_inverse_monoid)
+        .def("dual_symmetric_inverse_monoid",
+             &fpsemigroup::dual_symmetric_inverse_monoid)
+        .def("uniform_block_bijection_monoid",
+             &fpsemigroup::uniform_block_bijection_monoid)
+        .def("partition_monoid", &fpsemigroup::partition_monoid)
+        .def("brauer_monoid", &fpsemigroup::brauer_monoid)
+        .def("rectangular_band", &fpsemigroup::rectangular_band)
+        .def("stellar_monoid", &fpsemigroup::stellar_monoid)
+        .def("chinese_monoid", &fpsemigroup::chinese_monoid)
+        .def("monogenic_semigroup", &fpsemigroup::monogenic_semigroup)
+        .def("plactic_monoid", &fpsemigroup::plactic_monoid)
+        .def("stylic_monoid", &fpsemigroup::stylic_monoid)
+        .def("fibonacci_semigroup", &fpsemigroup::fibonacci_semigroup)
+        .def("temperley_lieb_monoid", &fpsemigroup::temperley_lieb_monoid)
+        .def("singular_brauer_monoid", &fpsemigroup::singular_brauer_monoid)
+        .def("orientation_preserving_monoid",
+             &fpsemigroup::orientation_preserving_monoid)
+        .def("orientation_reversing_monoid",
+             &fpsemigroup::orientation_reversing_monoid);
+  }
+}  // namespace libsemigroups

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -236,6 +236,7 @@ namespace libsemigroups {
     init_bmat8(m);
     init_cong(m);
     init_fpsemi(m);
+    init_fpsemi_examples(m);
     init_knuth_bendix(m);
     init_matrix(m);
     init_pbr(m);

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -30,6 +30,7 @@ namespace libsemigroups {
   void init_cong(py::module&);
   void init_forest(py::module&);
   void init_fpsemi(py::module&);
+  void init_fpsemi_examples(py::module&);
   void init_froidure_pin(py::module&);
   void init_kambites(py::module&);
   void init_konieczny(py::module&);

--- a/tests/test_fpsemi_examples.py
+++ b/tests/test_fpsemi_examples.py
@@ -14,16 +14,39 @@ This module contains some tests for fpsemi-examples.
 
 
 import pytest
+
 from libsemigroups_pybind11 import (
-    ReportGuard,
-    Presentation,
     presentation,
     ToddCoxeter,
     congruence_kind,
-    KnuthBendix,
-    Sims1
+    Sims1,
 )
-from libsemigroups_pybind11.fpsemigroup import *
+
+from libsemigroups_pybind11.fpsemigroup import (
+    make,
+    author,
+    symmetric_group,
+    alternating_group,
+    full_transformation_monoid,
+    partial_transformation_monoid,
+    symmetric_inverse_monoid,
+    dual_symmetric_inverse_monoid,
+    uniform_block_bijection_monoid,
+    partition_monoid,
+    brauer_monoid,
+    rectangular_band,
+    stellar_monoid,
+    chinese_monoid,
+    monogenic_semigroup,
+    plactic_monoid,
+    stylic_monoid,
+    fibonacci_semigroup,
+    temperley_lieb_monoid,
+    singular_brauer_monoid,
+    orientation_preserving_monoid,
+    orientation_reversing_monoid,
+)
+
 
 def test_symmetric_group_Carmichael():
     n = 5
@@ -38,6 +61,8 @@ def test_symmetric_group_Carmichael():
     for i in range(int(len(p.rules) / 2)):
         tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
     assert tc.number_of_classes() == 120
+
+    assert symmetric_group(5, author.Carmichael) == symmetric_group(5)
 
 
 def test_symmetric_group_Coxeter_Moser():
@@ -72,12 +97,11 @@ def test_symmetric_group_Moore():
 
 def test_symmetric_group_exceptions():
     with pytest.raises(TypeError):
-        symmetric_group("a")
-        symmetric_group([5])
-        symmetric_group(author.Carmichael)
+        symmetric_group(author.Sutov)
     with pytest.raises(RuntimeError):
         symmetric_group(2)
         symmetric_group(5, author.Sutov)
+
 
 def test_alternating_group_Moore():
     n = 6
@@ -93,10 +117,16 @@ def test_alternating_group_Moore():
         tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
     assert tc.number_of_classes() == 360
 
+    assert alternating_group(5, author.Moore) == alternating_group(5)
+
+
 def test_alternating_group_exceptions():
     with pytest.raises(RuntimeError):
         alternating_group(3, author.Moore)
         alternating_group(4, author.Iwahori)
+    with pytest.raises(TypeError):
+        alternating_group(author.Sutov)
+
 
 def test_full_transformation_monoid_Iwahori():
     n = 5
@@ -112,6 +142,11 @@ def test_full_transformation_monoid_Iwahori():
         tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
     assert tc.number_of_classes() == 3125
 
+    assert full_transformation_monoid(
+        5, author.Iwahori
+    ) == full_transformation_monoid(5)
+
+
 def test_full_transformation_monoid_Aizenstat():
     n = 5
     p = make(full_transformation_monoid(n, author.Aizenstat))
@@ -126,11 +161,15 @@ def test_full_transformation_monoid_Aizenstat():
         tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
     assert tc.number_of_classes() == 3125
 
+
 def test_full_transformation_monoid_exceptions():
     with pytest.raises(RuntimeError):
         full_transformation_monoid(3, author.Iwahori)
         full_transformation_monoid(3, author.Aizenstat)
         full_transformation_monoid(5, author.Coxeter)
+    with pytest.raises(TypeError):
+        full_transformation_monoid(author.Sutov)
+
 
 def test_partial_transformation_monoid_Sutov():
     n = 5
@@ -146,6 +185,11 @@ def test_partial_transformation_monoid_Sutov():
         tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
     assert tc.number_of_classes() == 7776
 
+    assert partial_transformation_monoid(
+        5, author.Sutov
+    ) == partial_transformation_monoid(5)
+
+
 def test_partial_transformation_monoid_Machine():
     p = make(partial_transformation_monoid(3, author.Machine))
     presentation.replace_word(p, [], [4])
@@ -159,11 +203,15 @@ def test_partial_transformation_monoid_Machine():
         tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
     assert tc.number_of_classes() == 64
 
+
 def test_partial_transformation_monoid_exceptions():
     with pytest.raises(RuntimeError):
         partial_transformation_monoid(3, author.Sutov)
         partial_transformation_monoid(4, author.Burnside)
         partial_transformation_monoid(4, author.Machine)
+    with pytest.raises(TypeError):
+        partial_transformation_monoid(author.Sutov)
+
 
 def test_symmetric_inverse_monoid_Sutov():
     n = 6
@@ -179,23 +227,43 @@ def test_symmetric_inverse_monoid_Sutov():
         tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
     assert tc.number_of_classes() == 13327
 
+    assert symmetric_inverse_monoid(
+        5, author.Sutov
+    ) == symmetric_inverse_monoid(5)
+
+
 def test_symmetric_inverse_monoid_exceptions():
     with pytest.raises(RuntimeError):
         symmetric_inverse_monoid(3, author.Sutov)
         symmetric_inverse_monoid(4, author.Burnside)
+    with pytest.raises(TypeError):
+        symmetric_inverse_monoid(author.Sutov)
+
 
 def test_dual_symmetric_inverse_monoid_Easdown_East_Fitzgerald():
-    s = dual_symmetric_inverse_monoid(5, author.Easdown + author.East + author.FitzGerald)
+    s = dual_symmetric_inverse_monoid(
+        5, author.Easdown + author.East + author.FitzGerald
+    )
     tc = ToddCoxeter(congruence_kind.twosided)
     tc.set_number_of_generators(6)
     for rule in s:
         tc.add_pair(rule[0], rule[1])
     assert tc.number_of_classes() == 6721
 
+    assert dual_symmetric_inverse_monoid(
+        5, author.Easdown + author.East + author.FitzGerald
+    ) == dual_symmetric_inverse_monoid(5)
+
+
 def test_dual_symmetric_inverse_monoid_exceptions():
     with pytest.raises(RuntimeError):
-        dual_symmetric_inverse_monoid(3, author.Easdown + author.East + author.FitzGerald)
+        dual_symmetric_inverse_monoid(
+            3, author.Easdown + author.East + author.FitzGerald
+        )
         dual_symmetric_inverse_monoid(5, author.Burnside)
+    with pytest.raises(TypeError):
+        dual_symmetric_inverse_monoid(author.Sutov)
+
 
 def test_uniform_block_bijection_monoid_Fitzgerald():
     s = uniform_block_bijection_monoid(6, author.FitzGerald)
@@ -205,10 +273,18 @@ def test_uniform_block_bijection_monoid_Fitzgerald():
         tc.add_pair(rule[0], rule[1])
     assert tc.number_of_classes() == 22482
 
-def test_dual_symmetric_inverse_monoid_exceptions():
+    assert uniform_block_bijection_monoid(
+        5, author.FitzGerald
+    ) == uniform_block_bijection_monoid(5)
+
+
+def test_uniform_block_bijection_monoid_exceptions():
     with pytest.raises(RuntimeError):
-        dual_symmetric_inverse_monoid(2, author.FitzGerald)
+        uniform_block_bijection_monoid(2, author.FitzGerald)
         uniform_block_bijection_monoid(5, author.Burnside)
+    with pytest.raises(TypeError):
+        uniform_block_bijection_monoid(author.Sutov)
+
 
 def test_partition_monoid_East():
     s = partition_monoid(4, author.East)
@@ -217,6 +293,9 @@ def test_partition_monoid_East():
     for rule in s:
         tc.add_pair(rule[0], rule[1])
     assert tc.number_of_classes() == 4140
+
+    assert partition_monoid(5, author.East) == partition_monoid(5)
+
 
 def test_partition_monoid_Machine():
     s = partition_monoid(3, author.Machine)
@@ -232,6 +311,9 @@ def test_partition_monoid_exceptions():
         partition_monoid(3, author.East)
         partition_monoid(4, author.Machine)
         partition_monoid(5, author.Sutov)
+    with pytest.raises(TypeError):
+        partition_monoid(author.Sutov)
+
 
 def test_brauer_monoid():
     s = brauer_monoid(6)
@@ -240,6 +322,12 @@ def test_brauer_monoid():
     for rule in s:
         tc.add_pair(rule[0], rule[1])
     assert tc.number_of_classes() == 10395
+
+
+def test_brauer_monoid_exceptions():
+    with pytest.raises(TypeError):
+        brauer_monoid(author.Sutov)
+
 
 def test_rectangular_band():
     s = rectangular_band(4, 5)
@@ -256,10 +344,14 @@ def test_rectangular_band():
         tc.add_pair(rule[0], rule[1])
     assert tc.number_of_classes() == 15
 
+
 def test_rectangular_band_exceptions():
     with pytest.raises(RuntimeError):
         rectangular_band(1, 0)
         rectangular_band(0, 1)
+    with pytest.raises(TypeError):
+        rectangular_band(author.Sutov, author.Sutov)
+
 
 def test_stellar_monoid():
     p = make(stellar_monoid(4))
@@ -268,10 +360,14 @@ def test_stellar_monoid():
 
     assert C.number_of_congruences(3) == 79237
 
+
 def test_stellar_monoid_exceptions():
     with pytest.raises(RuntimeError):
         stellar_monoid(0)
         stellar_monoid(1)
+    with pytest.raises(TypeError):
+        stellar_monoid(author.Sutov)
+
 
 def test_chinese_monoid():
     p = make(chinese_monoid(5))
@@ -280,10 +376,14 @@ def test_chinese_monoid():
 
     assert C.number_of_congruences(3) == 23504
 
+
 def test_chinese_monoid_exceptions():
     with pytest.raises(RuntimeError):
         chinese_monoid(0)
         chinese_monoid(1)
+    with pytest.raises(TypeError):
+        chinese_monoid(author.Sutov)
+
 
 def test_monogenic_semigroup():
     s = monogenic_semigroup(5, 9)
@@ -293,10 +393,14 @@ def test_monogenic_semigroup():
         tc.add_pair(rule[0], rule[1])
     assert tc.number_of_classes() == 13
 
+
 def test_monogenic_semigroup_exceptions():
     with pytest.raises(RuntimeError):
         monogenic_semigroup(4, 0)
         monogenic_semigroup(0, 0)
+    with pytest.raises(TypeError):
+        monogenic_semigroup(author.Sutov, author.Sutov)
+
 
 def test_plactic_monoid():
     p = make(plactic_monoid(4))
@@ -305,10 +409,14 @@ def test_plactic_monoid():
 
     assert C.number_of_congruences(4) == 106264
 
+
 def test_plactic_monoid_exceptions():
     with pytest.raises(RuntimeError):
         plactic_monoid(0)
         plactic_monoid(1)
+    with pytest.raises(TypeError):
+        plactic_monoid(author.Sutov)
+
 
 def test_stylic_monoid():
     p = make(stylic_monoid(5))
@@ -317,10 +425,14 @@ def test_stylic_monoid():
 
     assert C.number_of_congruences(5) == 19201
 
+
 def test_stylic_monoid_exceptions():
     with pytest.raises(RuntimeError):
         stylic_monoid(0)
         stylic_monoid(1)
+    with pytest.raises(TypeError):
+        stylic_monoid(author.Sutov)
+
 
 def test_fibonacci_semigroup():
     s = fibonacci_semigroup(2, 5)
@@ -330,11 +442,15 @@ def test_fibonacci_semigroup():
         tc.add_pair(rule[0], rule[1])
     assert tc.number_of_classes() == 11
 
+
 def test_fibonacci_semigroup_exceptions():
     with pytest.raises(RuntimeError):
         fibonacci_semigroup(0, 1)
         fibonacci_semigroup(1, 0)
         fibonacci_semigroup(0, 0)
+    with pytest.raises(TypeError):
+        fibonacci_semigroup(author.Sutov, author.Sutov)
+
 
 def test_temperley_lieb_monoid():
     p = make(temperley_lieb_monoid(8))
@@ -343,30 +459,38 @@ def test_temperley_lieb_monoid():
     p.validate()
     tc = ToddCoxeter(congruence_kind.twosided)
     tc.set_number_of_generators(8)
-    for i in range(int(len(p.rules)/2)):
-        tc.add_pair(p.rules[2*i], p.rules[2*i + 1])
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
     assert tc.number_of_classes() == 1430
+
 
 def test_temperley_lieb_monoid_exceptions():
     with pytest.raises(RuntimeError):
         temperley_lieb_monoid(0)
         temperley_lieb_monoid(1)
         temperley_lieb_monoid(2)
+    with pytest.raises(TypeError):
+        temperley_lieb_monoid(author.Sutov)
+
 
 def test_singular_brauer_monoid():
     p = make(singular_brauer_monoid(6))
     m = len(p.alphabet())
     tc = ToddCoxeter(congruence_kind.twosided)
     tc.set_number_of_generators(m)
-    for i in range(int(len(p.rules)/2)):
-        tc.add_pair(p.rules[2*i], p.rules[2*i + 1])
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
     assert tc.number_of_classes() == 9675
+
 
 def test_singular_brauer_monoid_exceptions():
     with pytest.raises(RuntimeError):
         singular_brauer_monoid(0)
         singular_brauer_monoid(1)
         singular_brauer_monoid(2)
+    with pytest.raises(TypeError):
+        singular_brauer_monoid(author.Sutov)
+
 
 def test_orientation_preserving_monoid():
     s = orientation_preserving_monoid(6)
@@ -376,11 +500,15 @@ def test_orientation_preserving_monoid():
         tc.add_pair(rule[0], rule[1])
     assert tc.number_of_classes() == 2742
 
+
 def test_orientation_preserving_monoid_exceptions():
     with pytest.raises(RuntimeError):
         orientation_preserving_monoid(0)
         orientation_preserving_monoid(1)
         orientation_preserving_monoid(2)
+    with pytest.raises(TypeError):
+        orientation_preserving_monoid(author.Sutov)
+
 
 def test_orientation_reversing_monoid():
     s = orientation_reversing_monoid(5)
@@ -390,8 +518,11 @@ def test_orientation_reversing_monoid():
         tc.add_pair(rule[0], rule[1])
     assert tc.number_of_classes() == 1015
 
+
 def test_orientation_reversing_monoid_exceptions():
     with pytest.raises(RuntimeError):
         orientation_reversing_monoid(0)
         orientation_reversing_monoid(1)
         orientation_reversing_monoid(2)
+    with pytest.raises(TypeError):
+        orientation_reversing_monoid(author.Sutov)

--- a/tests/test_fpsemi_examples.py
+++ b/tests/test_fpsemi_examples.py
@@ -1,0 +1,397 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022, M. T. Whyte
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+
+"""
+This module contains some tests for fpsemi-examples.
+"""
+
+# pylint: disable=fixme, missing-function-docstring
+# pylint: disable=missing-class-docstring, invalid-name
+
+
+import pytest
+from libsemigroups_pybind11 import (
+    ReportGuard,
+    Presentation,
+    presentation,
+    ToddCoxeter,
+    congruence_kind,
+    KnuthBendix,
+    Sims1
+)
+from libsemigroups_pybind11.fpsemigroup import *
+
+def test_symmetric_group_Carmichael():
+    n = 5
+    p = make(symmetric_group(n, author.Carmichael))
+    presentation.replace_word(p, [], [n - 1])
+    p.alphabet(n)
+    presentation.add_identity_rules(p, n - 1)
+    p.validate()
+
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(n)
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
+    assert tc.number_of_classes() == 120
+
+
+def test_symmetric_group_Coxeter_Moser():
+    n = 6
+    p = make(symmetric_group(n, author.Coxeter + author.Moser))
+    presentation.replace_word(p, [], [n - 1])
+    p.alphabet(n)
+    presentation.add_identity_rules(p, n - 1)
+    p.validate()
+
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(n)
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
+    assert tc.number_of_classes() == 720
+
+
+def test_symmetric_group_Moore():
+    n = 6
+    p = make(symmetric_group(n, author.Moore))
+    presentation.replace_word(p, [], [2])
+    p.alphabet(3)
+    presentation.add_identity_rules(p, 2)
+    p.validate()
+
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(3)
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
+    assert tc.number_of_classes() == 720
+
+
+def test_symmetric_group_exceptions():
+    with pytest.raises(TypeError):
+        symmetric_group("a")
+        symmetric_group([5])
+        symmetric_group(author.Carmichael)
+    with pytest.raises(RuntimeError):
+        symmetric_group(2)
+        symmetric_group(5, author.Sutov)
+
+def test_alternating_group_Moore():
+    n = 6
+    p = make(alternating_group(n, author.Moore))
+    presentation.replace_word(p, [], [n - 2])
+    p.alphabet(n - 1)
+    presentation.add_identity_rules(p, n - 2)
+    p.validate()
+
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(n - 1)
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
+    assert tc.number_of_classes() == 360
+
+def test_alternating_group_exceptions():
+    with pytest.raises(RuntimeError):
+        alternating_group(3, author.Moore)
+        alternating_group(4, author.Iwahori)
+
+def test_full_transformation_monoid_Iwahori():
+    n = 5
+    p = make(full_transformation_monoid(n, author.Iwahori))
+    presentation.replace_word(p, [], [n])
+    p.alphabet(n + 1)
+    presentation.add_identity_rules(p, n)
+    p.validate()
+
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(n + 1)
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
+    assert tc.number_of_classes() == 3125
+
+def test_full_transformation_monoid_Aizenstat():
+    n = 5
+    p = make(full_transformation_monoid(n, author.Aizenstat))
+    presentation.replace_word(p, [], [3])
+    p.alphabet(4)
+    presentation.add_identity_rules(p, 3)
+    p.validate()
+
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(4)
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
+    assert tc.number_of_classes() == 3125
+
+def test_full_transformation_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        full_transformation_monoid(3, author.Iwahori)
+        full_transformation_monoid(3, author.Aizenstat)
+        full_transformation_monoid(5, author.Coxeter)
+
+def test_partial_transformation_monoid_Sutov():
+    n = 5
+    p = make(partial_transformation_monoid(n, author.Sutov))
+    presentation.replace_word(p, [], [n + 1])
+    p.alphabet(n + 2)
+    presentation.add_identity_rules(p, n + 1)
+    p.validate()
+
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(n + 2)
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
+    assert tc.number_of_classes() == 7776
+
+def test_partial_transformation_monoid_Machine():
+    p = make(partial_transformation_monoid(3, author.Machine))
+    presentation.replace_word(p, [], [4])
+    p.alphabet(5)
+    presentation.add_identity_rules(p, 4)
+    p.validate()
+
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(5)
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
+    assert tc.number_of_classes() == 64
+
+def test_partial_transformation_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        partial_transformation_monoid(3, author.Sutov)
+        partial_transformation_monoid(4, author.Burnside)
+        partial_transformation_monoid(4, author.Machine)
+
+def test_symmetric_inverse_monoid_Sutov():
+    n = 6
+    p = make(symmetric_inverse_monoid(n, author.Sutov))
+    presentation.replace_word(p, [], [n])
+    p.alphabet(n + 1)
+    presentation.add_identity_rules(p, n)
+    p.validate()
+
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(n + 1)
+    for i in range(int(len(p.rules) / 2)):
+        tc.add_pair(p.rules[2 * i], p.rules[2 * i + 1])
+    assert tc.number_of_classes() == 13327
+
+def test_symmetric_inverse_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        symmetric_inverse_monoid(3, author.Sutov)
+        symmetric_inverse_monoid(4, author.Burnside)
+
+def test_dual_symmetric_inverse_monoid_Easdown_East_Fitzgerald():
+    s = dual_symmetric_inverse_monoid(5, author.Easdown + author.East + author.FitzGerald)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(6)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 6721
+
+def test_dual_symmetric_inverse_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        dual_symmetric_inverse_monoid(3, author.Easdown + author.East + author.FitzGerald)
+        dual_symmetric_inverse_monoid(5, author.Burnside)
+
+def test_uniform_block_bijection_monoid_Fitzgerald():
+    s = uniform_block_bijection_monoid(6, author.FitzGerald)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(7)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 22482
+
+def test_dual_symmetric_inverse_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        dual_symmetric_inverse_monoid(2, author.FitzGerald)
+        uniform_block_bijection_monoid(5, author.Burnside)
+
+def test_partition_monoid_East():
+    s = partition_monoid(4, author.East)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(5)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 4140
+
+def test_partition_monoid_Machine():
+    s = partition_monoid(3, author.Machine)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(5)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 203
+
+
+def test_partition_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        partition_monoid(3, author.East)
+        partition_monoid(4, author.Machine)
+        partition_monoid(5, author.Sutov)
+
+def test_brauer_monoid():
+    s = brauer_monoid(6)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(11)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 10395
+
+def test_rectangular_band():
+    s = rectangular_band(4, 5)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(9)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 20
+
+    s = rectangular_band(15, 1)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(16)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 15
+
+def test_rectangular_band_exceptions():
+    with pytest.raises(RuntimeError):
+        rectangular_band(1, 0)
+        rectangular_band(0, 1)
+
+def test_stellar_monoid():
+    p = make(stellar_monoid(4))
+    C = Sims1(congruence_kind.right)
+    C.short_rules(p)
+
+    assert C.number_of_congruences(3) == 79237
+
+def test_stellar_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        stellar_monoid(0)
+        stellar_monoid(1)
+
+def test_chinese_monoid():
+    p = make(chinese_monoid(5))
+    C = Sims1(congruence_kind.right)
+    C.short_rules(p)
+
+    assert C.number_of_congruences(3) == 23504
+
+def test_chinese_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        chinese_monoid(0)
+        chinese_monoid(1)
+
+def test_monogenic_semigroup():
+    s = monogenic_semigroup(5, 9)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(1)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 13
+
+def test_monogenic_semigroup_exceptions():
+    with pytest.raises(RuntimeError):
+        monogenic_semigroup(4, 0)
+        monogenic_semigroup(0, 0)
+
+def test_plactic_monoid():
+    p = make(plactic_monoid(4))
+    C = Sims1(congruence_kind.right)
+    C.short_rules(p)
+
+    assert C.number_of_congruences(4) == 106264
+
+def test_plactic_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        plactic_monoid(0)
+        plactic_monoid(1)
+
+def test_stylic_monoid():
+    p = make(stylic_monoid(5))
+    C = Sims1(congruence_kind.right)
+    C.short_rules(p)
+
+    assert C.number_of_congruences(5) == 19201
+
+def test_stylic_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        stylic_monoid(0)
+        stylic_monoid(1)
+
+def test_fibonacci_semigroup():
+    s = fibonacci_semigroup(2, 5)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(5)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 11
+
+def test_fibonacci_semigroup_exceptions():
+    with pytest.raises(RuntimeError):
+        fibonacci_semigroup(0, 1)
+        fibonacci_semigroup(1, 0)
+        fibonacci_semigroup(0, 0)
+
+def test_temperley_lieb_monoid():
+    p = make(temperley_lieb_monoid(8))
+    p.alphabet(8)
+    presentation.add_identity_rules(p, 7)
+    p.validate()
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(8)
+    for i in range(int(len(p.rules)/2)):
+        tc.add_pair(p.rules[2*i], p.rules[2*i + 1])
+    assert tc.number_of_classes() == 1430
+
+def test_temperley_lieb_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        temperley_lieb_monoid(0)
+        temperley_lieb_monoid(1)
+        temperley_lieb_monoid(2)
+
+def test_singular_brauer_monoid():
+    p = make(singular_brauer_monoid(6))
+    m = len(p.alphabet())
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(m)
+    for i in range(int(len(p.rules)/2)):
+        tc.add_pair(p.rules[2*i], p.rules[2*i + 1])
+    assert tc.number_of_classes() == 9675
+
+def test_singular_brauer_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        singular_brauer_monoid(0)
+        singular_brauer_monoid(1)
+        singular_brauer_monoid(2)
+
+def test_orientation_preserving_monoid():
+    s = orientation_preserving_monoid(6)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(3)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 2742
+
+def test_orientation_preserving_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        orientation_preserving_monoid(0)
+        orientation_preserving_monoid(1)
+        orientation_preserving_monoid(2)
+
+def test_orientation_reversing_monoid():
+    s = orientation_reversing_monoid(5)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(4)
+    for rule in s:
+        tc.add_pair(rule[0], rule[1])
+    assert tc.number_of_classes() == 1015
+
+def test_orientation_reversing_monoid_exceptions():
+    with pytest.raises(RuntimeError):
+        orientation_reversing_monoid(0)
+        orientation_reversing_monoid(1)
+        orientation_reversing_monoid(2)


### PR DESCRIPTION
**Note: This PR is on top of #84**

This PR adds functionality for the `fpsemi-examples` presentations, addressing issue #83. It is not entirely finished, but in a state where @james-d-mitchell and I might discuss finishing touches. This might include:

- I haven't yet documented addition on the author values, since I'm not sure how this should look.
- There is a bug, I think possibly related to setting default author values, which I'll describe in a comment below. I've kept the default author value for `symmetric_group`, but not set this up for other functions yet. I'll do this after we've figured out what's going on.
- I will also double check everything's in order (mainly the documentation) before marking this as ready for review.