### PR TITLE
Add functionality for `ToddCoxeter` function `to_gap_string`

### DIFF
--- a/docs/source/api/toddcoxeter.rst
+++ b/docs/source/api/toddcoxeter.rst
@@ -141,6 +141,7 @@ of (any version of) the Todd-Coxeter algorithm.
    ToddCoxeter.strategy_options
    ToddCoxeter.timed_out
    ToddCoxeter.word_to_class_index
+   ToddCoxeter.to_gap_string
 
 .. autoclass:: ToddCoxeter
    :members:

--- a/src/todd-coxeter.cpp
+++ b/src/todd-coxeter.cpp
@@ -405,7 +405,7 @@ namespace libsemigroups {
                Randomly shuffle all existing generating pairs.
              )pbdoc")
         .def("report_every",
-             (void (congruence::ToddCoxeter::*)(std::chrono::nanoseconds))
+             (void(congruence::ToddCoxeter::*)(std::chrono::nanoseconds))
                  & Runner::report_every,
              py::arg("t"),
              runner_doc_strings::report_every)
@@ -418,12 +418,12 @@ namespace libsemigroups {
         .def("kill", &congruence::ToddCoxeter::kill, runner_doc_strings::kill)
         .def("run", &congruence::ToddCoxeter::run, runner_doc_strings::run)
         .def("run_for",
-             (void (congruence::ToddCoxeter::*)(std::chrono::nanoseconds))
+             (void(congruence::ToddCoxeter::*)(std::chrono::nanoseconds))
                  & Runner::run_for,
              py::arg("t"),
              runner_doc_strings::run_for)
         .def("run_until",
-             (void (congruence::ToddCoxeter::*)(std::function<bool()>&))
+             (void(congruence::ToddCoxeter::*)(std::function<bool()>&))
                  & Runner::run_until,
              py::arg("func"),
              runner_doc_strings::run_until)
@@ -560,6 +560,15 @@ namespace libsemigroups {
             R"pbdoc(
               Returns an iterator to the normal forms of the congruence
               represented by an instance of :py:class:`ToddCoxeter`.
-            )pbdoc");
+            )pbdoc")
+        .def("to_gap_string",
+             &congruence::ToddCoxeter::to_gap_string,
+             R"pbdoc(
+              Returns a string containing a GAP definition of the finitely presented semigroup represented by a ``ToddCoxeter`` instance.
+
+              :parameters: None
+
+              :returns: A string
+             )pbdoc");
   }
 }  // namespace libsemigroups

--- a/tests/test_todd_coxeter.py
+++ b/tests/test_todd_coxeter.py
@@ -15,6 +15,11 @@ from datetime import timedelta
 
 import pytest
 
+from libsemigroups_pybind11.tools import (
+    libsemigroups_version,
+    compare_version_numbers,
+)
+
 from libsemigroups_pybind11 import (
     FroidurePin,
     KnuthBendix,
@@ -346,6 +351,7 @@ def test_096():
     assert copy.complete()
     assert copy.compatible()
 
+
 def test_to_gap_string():
     ReportGuard(False)
     tc = ToddCoxeter(congruence_kind.twosided)
@@ -356,11 +362,13 @@ def test_to_gap_string():
     tc = ToddCoxeter(congruence_kind.left)
     tc.set_number_of_generators(2)
     tc.add_pair([0, 1], [1, 0])
-    with pytest.raises(RuntimeError):
-        tc.to_gap_string()
+    if compare_version_numbers(libsemigroups_version(), "2.6.0"):
+        with pytest.raises(RuntimeError):
+            tc.to_gap_string()
 
     tc = ToddCoxeter(congruence_kind.right)
     tc.set_number_of_generators(2)
     tc.add_pair([0, 1], [1, 0])
-    with pytest.raises(RuntimeError):
-        tc.to_gap_string()
+    if compare_version_numbers(libsemigroups_version(), "2.6.0"):
+        with pytest.raises(RuntimeError):
+            tc.to_gap_string()

--- a/tests/test_todd_coxeter.py
+++ b/tests/test_todd_coxeter.py
@@ -345,3 +345,22 @@ def test_096():
     assert copy.number_of_classes() == 1
     assert copy.complete()
     assert copy.compatible()
+
+def test_to_gap_string():
+    ReportGuard(False)
+    tc = ToddCoxeter(congruence_kind.twosided)
+    tc.set_number_of_generators(2)
+    tc.add_pair([0, 1], [1, 0])
+    assert len(tc.to_gap_string()) > 0
+
+    tc = ToddCoxeter(congruence_kind.left)
+    tc.set_number_of_generators(2)
+    tc.add_pair([0, 1], [1, 0])
+    with pytest.raises(RuntimeError):
+        tc.to_gap_string()
+
+    tc = ToddCoxeter(congruence_kind.right)
+    tc.set_number_of_generators(2)
+    tc.add_pair([0, 1], [1, 0])
+    with pytest.raises(RuntimeError):
+        tc.to_gap_string()


### PR DESCRIPTION
This PR adds functionality for the `ToddCoxeter` function `to_gap_string`.

I think the CI will fail until there is a release of `libsemigroups` which includes the PR which adds argument checking for the sidedness of the congruence.