### PR TITLE
Improve `ActionDigraph` `graphviz` colour capability

### DIFF
--- a/libsemigroups_pybind11/action_digraph_helper.py
+++ b/libsemigroups_pybind11/action_digraph_helper.py
@@ -78,13 +78,21 @@ def dot(d: ActionDigraph) -> graphviz.Digraph:
        d = action_digraph_helper.make(5, [[1, 0], [2], [3, 4]])
        action_digraph_helper.dot(d).view()
     """
-    colors = [
-        (238, 20, 135),
-        (0, 221, 164),
-        (86, 151, 209),
-        (249, 185, 131),
-        (150, 114, 196),
+    # the below is the muted, qualatative colour scheme from https://personal.sron.nl/~pault/
+    color_scheme = [
+        (204, 102, 119),  # rose
+        (221, 204, 119),  # sand
+        (17, 119, 51),  # green
+        (136, 204, 238),  # cyan
+        (68, 170, 153),  # teal
+        (136, 34, 85),  # wine
+        (68, 170, 153),  # teal
+        (153, 153, 51),  # olive
+        (51, 34, 136),  # indigo
     ]
+    # the same set of colours is used cyclically
+    k = int(d.out_degree() / len(color_scheme)) + 1
+    colors = k * color_scheme
     # Add some tests too
     result = graphviz.Digraph()
     result.attr("node", shape="circle")

--- a/tests/test_actiondigraph.py
+++ b/tests/test_actiondigraph.py
@@ -872,7 +872,7 @@ def test_dot():
     d = action_digraph_helper.make(3, l)
     assert (
         str(action_digraph_helper.dot(d))
-        == 'digraph {\n\tnode [shape=circle]\n\t0\n\t1\n\t2\n\t0 -> 0 [label=0 color="#ee1487"]\n\t0 -> 1 [label=1 color="#0dda4"]\n\t1 -> 1 [label=0 color="#ee1487"]\n\t1 -> 0 [label=1 color="#0dda4"]\n\t2 -> 2 [label=0 color="#ee1487"]\n\t2 -> 2 [label=1 color="#0dda4"]\n}\n'  # pylint: disable=line-too-long
+        == 'digraph {\n\tnode [shape=circle]\n\t0\n\t1\n\t2\n\t0 -> 0 [label=0 color="#cc6677"]\n\t0 -> 1 [label=1 color="#ddcc77"]\n\t1 -> 1 [label=0 color="#cc6677"]\n\t1 -> 0 [label=1 color="#ddcc77"]\n\t2 -> 2 [label=0 color="#cc6677"]\n\t2 -> 2 [label=1 color="#ddcc77"]\n}\n'  # pylint: disable=line-too-long
     )
 
     l = list(12 * [i] for i in range(4))

--- a/tests/test_actiondigraph.py
+++ b/tests/test_actiondigraph.py
@@ -874,3 +874,11 @@ def test_dot():
         str(action_digraph_helper.dot(d))
         == 'digraph {\n\tnode [shape=circle]\n\t0\n\t1\n\t2\n\t0 -> 0 [label=0 color="#ee1487"]\n\t0 -> 1 [label=1 color="#0dda4"]\n\t1 -> 1 [label=0 color="#ee1487"]\n\t1 -> 0 [label=1 color="#0dda4"]\n\t2 -> 2 [label=0 color="#ee1487"]\n\t2 -> 2 [label=1 color="#0dda4"]\n}\n'  # pylint: disable=line-too-long
     )
+
+    l = list(12 * [i] for i in range(4))
+
+    d = action_digraph_helper.make(4, l)
+    assert (
+        str(action_digraph_helper.dot(d))
+        == 'digraph {\n\tnode [shape=circle]\n\t0\n\t1\n\t2\n\t3\n\t0 -> 0 [label=0 color="#cc6677"]\n\t0 -> 0 [label=1 color="#ddcc77"]\n\t0 -> 0 [label=2 color="#117733"]\n\t0 -> 0 [label=3 color="#88ccee"]\n\t0 -> 0 [label=4 color="#44aa99"]\n\t0 -> 0 [label=5 color="#882255"]\n\t0 -> 0 [label=6 color="#44aa99"]\n\t0 -> 0 [label=7 color="#999933"]\n\t0 -> 0 [label=8 color="#332288"]\n\t0 -> 0 [label=9 color="#cc6677"]\n\t0 -> 0 [label=10 color="#ddcc77"]\n\t0 -> 0 [label=11 color="#117733"]\n\t1 -> 1 [label=0 color="#cc6677"]\n\t1 -> 1 [label=1 color="#ddcc77"]\n\t1 -> 1 [label=2 color="#117733"]\n\t1 -> 1 [label=3 color="#88ccee"]\n\t1 -> 1 [label=4 color="#44aa99"]\n\t1 -> 1 [label=5 color="#882255"]\n\t1 -> 1 [label=6 color="#44aa99"]\n\t1 -> 1 [label=7 color="#999933"]\n\t1 -> 1 [label=8 color="#332288"]\n\t1 -> 1 [label=9 color="#cc6677"]\n\t1 -> 1 [label=10 color="#ddcc77"]\n\t1 -> 1 [label=11 color="#117733"]\n\t2 -> 2 [label=0 color="#cc6677"]\n\t2 -> 2 [label=1 color="#ddcc77"]\n\t2 -> 2 [label=2 color="#117733"]\n\t2 -> 2 [label=3 color="#88ccee"]\n\t2 -> 2 [label=4 color="#44aa99"]\n\t2 -> 2 [label=5 color="#882255"]\n\t2 -> 2 [label=6 color="#44aa99"]\n\t2 -> 2 [label=7 color="#999933"]\n\t2 -> 2 [label=8 color="#332288"]\n\t2 -> 2 [label=9 color="#cc6677"]\n\t2 -> 2 [label=10 color="#ddcc77"]\n\t2 -> 2 [label=11 color="#117733"]\n\t3 -> 3 [label=0 color="#cc6677"]\n\t3 -> 3 [label=1 color="#ddcc77"]\n\t3 -> 3 [label=2 color="#117733"]\n\t3 -> 3 [label=3 color="#88ccee"]\n\t3 -> 3 [label=4 color="#44aa99"]\n\t3 -> 3 [label=5 color="#882255"]\n\t3 -> 3 [label=6 color="#44aa99"]\n\t3 -> 3 [label=7 color="#999933"]\n\t3 -> 3 [label=8 color="#332288"]\n\t3 -> 3 [label=9 color="#cc6677"]\n\t3 -> 3 [label=10 color="#ddcc77"]\n\t3 -> 3 [label=11 color="#117733"]\n}\n'  # pylint: disable=line-too-long
+    )


### PR DESCRIPTION
This PR improves the `graphviz` colour capability for `ActionDigraph` objects, as discussed in issue #100.

More specifically: a nice palate of nine colourblind accessible colours due to [Paul Tol](https://personal.sron.nl/~pault/) is used. Where a graph has more than nine distinct labels whose edges need coloured, these nine colours are simply reused cyclically. This seemed like a reasonable way of doing things.