### PR TITLE
present: add further manip. funcs

### DIFF
--- a/docs/source/presentations/present-helpers.rst
+++ b/docs/source/presentations/present-helpers.rst
@@ -54,6 +54,10 @@ Contents
      - Greedily reduce the length of the presentation using
        :py:func:`longest_common_subword`.
 
+   * - :py:func:`is_strongly_compressible`
+     - Returns ``True`` if a :math:`1`-relation presentation can be strongly
+       compressed.
+
    * - :py:func:`length`
      - Return the sum of the lengths of the rules.
 
@@ -84,6 +88,10 @@ Contents
      - If there are rules :math:`u = v` and :math:`v = w` where :math:`\lvert w
        \rvert < \lvert v \rvert`, then replace :math:`u = v` with :math:`u =
        w`.
+
+   * - :py:func:`reduce_to_2_generators`
+     - Reduce the number of generators in a :math:`1`-relation presentation to
+       ``2``.
 
    * - :py:func:`redundant_rule`
      - Returns the index of the left hand side of a redundant rule.
@@ -119,6 +127,9 @@ Contents
    * - :py:func:`sort_rules`
      - Sort the rules :math:`u_1 = v_1, \ldots, u_n = v_n` so that :math:`u_1
        v_1 < \cdots < u_n v_n`, where :math:`<` is the shortlex order.
+
+   * - :py:func:`strongly_compress`
+     - Strongly compress a :math:`1`-relation presentation.
 
 Full API
 --------
@@ -367,6 +378,28 @@ Full API
      if :py:func:`longest_common_subword` or :py:func:`replace_word` does.
 
 
+.. py:function:: is_strongly_compressible(p: Presentation) -> bool
+
+   Returns ``True`` if the :math:`1`-relation presentation can be strongly
+   compressed.
+
+   A :math:`1`-relation presentation is *strongly compressible* if both
+   relation words start with the same letter and end with the same letter.
+   In other words, if the alphabet of the presentation ``p`` is :math:`A` and
+   the relation words are of the form :math:`aub = avb` where :math:`a, b\in A`
+   (possibly :math:`a = b`) and :math:`u, v\in A^*`, then ``p`` is strongly
+   compressible. See `Section 3.2`_ for details.
+
+   .. _Section 3.2: https://doi.org/10.1007/s00233-021-10216-8
+
+   :param p:  the presentation
+   :type p: Presentation
+
+   :returns: A value of type ``bool``.
+
+   .. seealso:: :py:func:`strongly_compress`
+
+
 .. py:function:: length(p: Presentation) -> int
 
    Return the sum of the lengths of the rules.
@@ -534,6 +567,35 @@ Full API
       ['a', 'aaa', 'a', 'aaaaa']
 
 
+.. py:function:: reduce_to_2_generators(p: Presentation) -> None
+
+     Reduce the number of generators in a :math:`1`-relation presentation to
+     ``2``.
+
+     Returns ``True`` if the :math:`1`-relation presentation ``p`` has been
+     modified and ``False`` if not.
+
+     A :math:`1`-relation presentation is *left cycle-free* if the relation
+     words start with distinct letters. In other words, if the alphabet of the
+     presentation ``p`` is :math:`A` and the relation words are of the form
+     :math:`au = bv` where :math:`a, b\in A` with :math:`a \neq b` and
+     :math:`u, v \in A^*`, then ``p`` is left cycle-free. The word problem for
+     a left cycle-free :math:`1`-relation monoid is solvable if the word
+     problem for the modified version obtained from this function is solvable.
+
+     :param p:  the presentation
+     :type p: Presentation
+     :param x:
+       determines the choice of letter to use, ``0`` uses
+       ``p.rules[0].front()`` and ``1`` uses ``p.rules[1].front()`` (defaults to:
+       ``0``).
+     :type x: int
+
+     :returns: A value of type ``bool``.
+
+     :raises RuntimeError: if ``index`` is not ``0`` or ``1``.
+
+
 .. py:function:: redundant_rule(p: Presentation, t: datetime.timedelta) -> int
 
    Return the index of the the left hand side of a redundant rule.
@@ -573,9 +635,9 @@ Full API
       >>> presentation.add_rule(p, "ab", "ba")
       >>> presentation.add_rule(p, "bab", "abb")
       >>> t = timedelta(seconds = 1)
-      >>> p.rules  
+      >>> p.rules
       ['ab', 'ba', 'bab', 'abb']
-      >>> presentation.redundant_rule(p, t) 
+      >>> presentation.redundant_rule(p, t)
       2
 
 
@@ -770,3 +832,19 @@ Full API
    :type p: Presentation
 
    :returns: None
+
+
+.. py:function:: strongly_compress(p: Presentation) -> None
+
+   Strongly compress a :math:`1`-relation presentation.
+
+   Returns ``True`` if the :math:`1`-relation presentation ``p`` has been
+   modified and ``False`` if not. The word problem is solvable for the input
+   presentation if it is solvable for the modified version.
+
+   :param p:  the presentation
+   :type p: Presentation
+
+   :returns: A value of type ``bool``.
+
+   .. seealso:: :py:func:`is_strongly_compressible`

--- a/etc/catch-cpp-to-pytest.vim
+++ b/etc/catch-cpp-to-pytest.vim
@@ -28,7 +28,11 @@ function! DoxyToSphinx()
   silent '<,'>s/``true``/``True``/ge
   silent '<,'>s/``false``/``False``/ge
   silent '<,'>s/\\warning/.. warning::\r/ge
+  silent '<,'>s/\\sa/.. seealso::\r/ge
   silent '<,'>s/\\complexity/:Complexity:\r       /ge
+  silent '<,'>s/\\f\$\(.\{-}\)\\f\$/:math:`\1`/ge
+  silent '<,'>s/:math:``\(.\{-}\)``/:math:`\1`/ge
+  silent '<,'>s/``\(.\{-}\)``_/`\1`_/ge
 endfunction
 
 map! <F1> <ESC>:call CatchCPPToPytest()<CR>i

--- a/libsemigroups_pybind11/presentation.py
+++ b/libsemigroups_pybind11/presentation.py
@@ -49,6 +49,9 @@ from _libsemigroups_pybind11 import (
     longest_rule_length,
     shortest_rule_length,
     make_semigroup,
+    is_strongly_compressible,
+    strongly_compress,
+    reduce_to_2_generators,
 )
 
 

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -155,6 +155,13 @@ namespace libsemigroups {
                std::string const&             s) -> Presentation<std::string> {
               return make<Presentation<std::string>>(p, s);
             });
+      m.def("is_strongly_compressible",
+            &presentation::is_strongly_compressible<T>);
+      m.def("strongly_compress", &presentation::strongly_compress<T>);
+      m.def("reduce_to_2_generators",
+            &presentation::reduce_to_2_generators<T>,
+            py::arg("p"),
+            py::arg("index") = 0);
     }
   }  // namespace
 

--- a/tests/test_actiondigraph.py
+++ b/tests/test_actiondigraph.py
@@ -12,7 +12,7 @@ libsemigroups_pybind11.
 """
 
 # pylint: disable=no-name-in-module, missing-function-docstring, invalid-name,
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code, too-many-lines
 
 import pytest
 from libsemigroups_pybind11 import (
@@ -25,8 +25,6 @@ from libsemigroups_pybind11 import (
     is_acyclic,
     topological_sort,
     wilo,
-    compare_version_numbers,
-    libsemigroups_version,
 )
 
 
@@ -62,11 +60,7 @@ def test_001():
 def test_003():
     g = ActionDigraph(17, 31)
     for i in range(17):
-        if compare_version_numbers("2.6.2", libsemigroups_version()):
-            with pytest.raises(RuntimeError):
-                g.number_of_scc()
-        else:
-            g.number_of_scc()
+        g.number_of_scc()
 
         for j in range(31):
             g.add_edge(i, (7 * i + 23 * j) % 17, j)


### PR DESCRIPTION
This adds some more features to the `presentation` submodule, the tests will fail until `libsemigroups` v2.7.0 is released.