### PR TITLE
Some intermediate work

### DIFF
--- a/libsemigroups_pybind11/__init__.py
+++ b/libsemigroups_pybind11/__init__.py
@@ -20,6 +20,16 @@ DISCLAIMER = (
     "(You should not see this message unless you are installing libsemigroups_pybind11 from its "
     "sources. If you are not installing from the sources, please raise an issue at "
     "https://github.com/libsemigroups/libsemigroups_pybind11)"
+from _libsemigroups_pybind11 import (
+    NEGATIVE_INFINITY,
+    POSITIVE_INFINITY,
+    UNDEFINED,
+    Forest,
+    Gabow,
+    Paths,
+    WordGraph,
+    algorithm,
+    order,
 )
 
 assert pkgconfig.exists("libsemigroups")

--- a/src/bipart.cpp
+++ b/src/bipart.cpp
@@ -1,0 +1,251 @@
+//
+// libsemigroups_pybind11
+// Copyright (C) 2021 James D. Mitchell
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// C std headers....
+#include <stddef.h>  // for size_t
+#include <stdint.h>  // for uint32_t
+
+// C++ stl headers....
+#include <initializer_list>  // for initializer_list
+#include <vector>            // for vector
+
+// libsemigroups....
+#include <libsemigroups/bipart.hpp>  // for Bipartition, operator!=, operator*
+
+// pybind11....
+#include <pybind11/operators.h>  // for self, self_t, operator!=, operator*
+#include <pybind11/pybind11.h>   // for class_, make_iterator, init, module
+#include <pybind11/stl.h>
+
+// libsemigroups_pybind11....
+#include "main.hpp"  // for init_bipart
+
+namespace py = pybind11;
+
+namespace libsemigroups { /*
+   // TODO(later) implement Blocks and uncomment the def's below.
+
+   void init_bipart(py::module& m) {
+     py::class_<Bipartition>(m,
+                             "Bipartition",
+                             R"pbdoc(
+    A *bipartition* is a partition of the set :math:`\{0, ..., 2n - 1\}` for
+    some non-negative integer :math:`n` see the `Semigroups package for GAP
+    documentation <https://semigroups.github.io/Semigroups/doc/chap3_mj.html>`_
+    for more details.
+                             )pbdoc")
+         .def(py::init<Bipartition const&>())
+         .def_static("make_identity",
+                     py::overload_cast<size_t>(&Bipartition::identity),
+                     py::arg("n"),
+                     R"pbdoc(
+                       Returns an identity bipartition.
+
+                       :Parameters: **n** (int) - the degree of the identity to
+   be returned.
+
+                       :Returns: A newly constructed ``Bipartition``.
+                    )pbdoc")
+         .def("identity",
+              py::overload_cast<>(&Bipartition::identity, py::const_),
+              R"pbdoc(
+                Returns an identity bipartition.
+
+
+                :Returns: A newly constructed ``Bipartition``.
+              )pbdoc")
+         .def_static("make",
+                     &Bipartition::make<std::vector<uint32_t> const&>,
+                     R"pbdoc(
+                       Validates the arguments, constructs a bipartition and
+                       validates it.
+                     )pbdoc")
+         .def("product_inplace",
+              &Bipartition::product_inplace,
+              py::arg("x"),
+              py::arg("y"),
+              py::arg("thread_id") = 0,
+              R"pbdoc(
+                Modify the current bipartition in-place to contain the product
+                of two bipartitions.
+
+                :param x: the first bipartition to multiply
+                :type x: Bipartition
+                :param y: the second bipartition to multiply
+                :type y: Bipartition
+                :param thread_id: the index of the calling thread (defaults to
+   0) :type thread_id: int
+
+                :return: (None)
+              )pbdoc")
+         .def(
+             "__getitem__",
+             [](const Bipartition& a, size_t b) -> uint32_t { return a.at(b); },
+             py::arg("i"),
+             py::is_operator(),
+             R"pbdoc(
+               Returns the index of the block containing a value.
+
+               :param i: an integer
+               :type i: int
+
+               :return: A ``int``.
+             )pbdoc")
+         // TODO(later) not implemented in libsemigroups
+         // .def(py::self <= py::self)  // no doc
+         // .def(py::self > py::self)   // no doc
+         // .def(py::self >= py::self)  // no doc
+         .def(py::self != py::self)  // no doc
+         .def(pybind11::self == pybind11::self,
+              py::arg("that"),
+              R"pbdoc(
+                Equality comparison.
+
+                Returns ``True`` if ``self`` equals ``that`` by comparing their
+                image values.
+
+                :param that: the ``Bipartition`` for comparison.
+                :type that: Bipartition
+
+                :returns: A ``bool``.
+              )pbdoc")
+         .def(pybind11::self < pybind11::self,
+              py::arg("that"),
+              R"pbdoc(
+                Less than comparison.
+
+                Returns ``True`` if ``self`` is less than ``that``.
+
+                :param that: the ``Bipartition`` for comparison.
+                :type that: Bipartition
+
+                :returns: A ``bool``.
+             )pbdoc")
+         .def(py::self * py::self,
+              py::arg("that"),
+              R"pbdoc(
+                Right multiply ``self`` by ``that``.
+
+                :param that: the ``Bipartition`` to multiply with.
+                :type that: Bipartition
+
+                :returns: A ``Bipartition``.
+              )pbdoc")
+         .def("degree",
+              &Bipartition::degree,
+              R"pbdoc(
+                Returns the degree of the ``Bipartition``.
+
+                :Parameters: None.
+                :return: An ``int``.
+              )pbdoc")
+         .def("is_transverse_block",
+              &Bipartition::is_transverse_block,
+              py::arg("index"),
+              R"pbdoc(
+                Check if a block is a transverse block.
+
+                :param index: the index of a block
+                :type index: int
+
+                :return: A ``bool``.
+              )pbdoc")
+         .def("number_of_blocks",
+              &Bipartition::number_of_blocks,
+              R"pbdoc(
+                Returns the number of blocks in a ``Bipartition``.
+
+                :Parameters: None.
+                :return: An ``int``.
+              )pbdoc")
+         .def("rank",
+              &Bipartition::rank,
+              R"pbdoc(
+                Returns the number of transverse blocks.
+
+                :Parameters: None.
+                :return: An ``int``
+              )pbdoc")
+         .def("__hash__",
+              &Bipartition::hash_value,
+              R"pbdoc(
+                Returns a hash value.
+
+                :Parameters: None.
+                :return: An ``int``
+              )pbdoc")
+         .def("number_of_right_blocks",
+              &Bipartition::number_of_right_blocks,
+              R"pbdoc(
+                Returns the number of blocks containing a negative integer.
+
+                :Parameters: None.
+                :return: An ``int``.
+              )pbdoc")
+         .def("number_of_left_blocks",
+              &Bipartition::number_of_left_blocks,
+              R"pbdoc(
+                Returns the number of blocks containing a positive integer.
+
+                :Parameters: None.
+                :return: An ``int``.
+              )pbdoc")
+         .def(
+             "lookup",
+             [](Bipartition& x) {
+               // TODO(later) because cbegin_lookup points to a
+   std::vector<bool>
+               // I couldn't figure out how to use an make_iterator here
+               return std::vector<bool>(x.cbegin_lookup(), x.cend_lookup());
+             },
+             R"pbdoc(
+               Returns a list whose ``i``-th entry indicates whether or not the
+               block with index ``i`` is transverse or not.
+
+               :Parameters: None.
+               :return: A ``list``.
+             )pbdoc")
+         .def(
+             "left_blocks",
+             [](Bipartition const& x) {
+               return py::make_iterator(x.cbegin_left_blocks(),
+                                        x.cend_left_blocks());
+             },
+             R"pbdoc(
+                Returns an iterator pointing to the index of the first left
+                block.
+
+               :Parameters: None.
+               :return: An iterator.
+              )pbdoc")
+         .def(
+             "right_blocks",
+             [](Bipartition const& x) {
+               return py::make_iterator(x.cbegin_right_blocks(),
+                                        x.cend_right_blocks());
+             },
+             R"pbdoc(
+               Returns an iterator pointing to the index of the first right
+               block.
+
+               :Parameters: None.
+               :return: An iterator.
+             )pbdoc");
+   }
+ */
+}  // namespace libsemigroups

--- a/src/bmat8.cpp
+++ b/src/bmat8.cpp
@@ -1,0 +1,324 @@
+//
+// libsemigroups - C++ library for semigroups and monoids
+// Copyright (C) 2021 James D. Mitchell
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// C std headers....
+#include <stddef.h>  // for size_t
+#include <stdint.h>  // for uint64_t
+
+// C++ stl headers....
+#include <initializer_list>  // for initializer_list
+#include <vector>            // for vector
+
+// libsemigroups....
+#include <libsemigroups/bmat8.hpp>  // for BMat8, col_space_size, minimum_dim
+#include <libsemigroups/detail/string.hpp>  // for to_string
+
+// pybind11....
+#include <pybind11/operators.h>  // for self, operator*, self_t
+#include <pybind11/pybind11.h>   // for class_, init, module
+#include <pybind11/stl.h>
+
+// libsemigroups_pybind11....
+#include "main.hpp"  // for init_bmat8
+
+namespace py = pybind11;
+
+namespace libsemigroups { /*
+   void init_bmat8(py::module& m) {
+     py::class_<BMat8>(m, "BMat8")
+         .def(py::init<>(), R"pbdoc(
+       Returns an uninitialised BMat8.
+       )pbdoc")
+         .def(py::init<uint64_t>())
+         .def(py::init<BMat8 const&>())
+         .def(py::init<std::vector<std::vector<bool>> const&>())
+         .def("__eq__", &BMat8::operator==)
+         .def("__lt__", &BMat8::operator<)  // NOLINT(whitespace/operators)
+         .def("get",
+              &BMat8::get,
+              py::arg("i"),
+              py::arg("j"),
+              R"pbdoc(
+                Returns the entry in the (i, j)th position.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.get(0, 1)
+                   True
+                   >>> x.get(1, 1)
+                   False
+              )pbdoc")
+
+         .def("set",
+              &BMat8::set,
+              py::arg("i"),
+              py::arg("j"),
+              py::arg("val"),
+              R"pbdoc(
+                Sets the (i, j)th entry to ``val``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.set(1,1,1)
+                   >>> x
+                   01000000
+                   11000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   <BLANKLINE>
+               )pbdoc")
+
+         .def("to_int",
+              &BMat8::to_int,
+              R"pbdoc(
+                Returns the integer representation of the ``BMat8``, that is an
+                integer obtained by interpreting an 8 x 8 ``BMat8`` as a
+                sequence of 64 bits (reading rows left to right, from top to
+                bottom) and then realising this sequence as an integer.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.to_int()
+                   4647714815446351872
+              )pbdoc")
+
+         .def("transpose",
+              &BMat8::transpose,
+              R"pbdoc(
+                Returns the transpose of ``self``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[1, 0], [1, 0]])
+                   >>> x.transpose()
+                   11000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   <BLANKLINE>
+               )pbdoc")
+
+         .def(py::self * py::self)
+         .def_static("random", py::overload_cast<>(&BMat8::random))
+         .def_static("random", py::overload_cast<size_t>(&BMat8::random))
+         .def("swap",
+              &BMat8::swap,
+              py::arg("other"),
+              R"pbdoc(
+                Swaps the contents of ``self`` and ``other``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> y = BMat8([[1, 1], [0, 0]])
+                   >>> BMat8.swap(x,y)
+                   >>> x
+                   11000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   <BLANKLINE>
+                   >>> y
+                   01000000
+                   10000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   <BLANKLINE>
+              )pbdoc")
+         .def("row_space_basis",
+              &BMat8::row_space_basis,
+              R"pbdoc(
+                This method returns a ``BMat8`` whose non-zero rows form a basis
+   for the row space of ``self``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.row_space_basis()
+                   10000000
+                   01000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   <BLANKLINE>
+              )pbdoc")
+         .def("col_space_basis",
+              &BMat8::col_space_basis,
+              R"pbdoc(
+                This method returns a ``BMat8`` whose non-zero columns form a
+   basis for the column space of ``self``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.col_space_basis()
+                   10000000
+                   01000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   <BLANKLINE>
+              )pbdoc")
+
+         .def("rows",
+              &BMat8::rows,
+              R"pbdoc(
+                This method returns a list of integers representing the rows of
+                ``self``. The list will always be of length 8, even if ``self``
+                was constructed with fewer rows.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.rows()
+                   [64, 128, 0, 0, 0, 0, 0, 0]
+               )pbdoc")
+
+         .def("row_space_size",
+              &BMat8::row_space_size,
+              R"pbdoc(
+                Returns the size of the row space of ``self``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.row_space_size()
+                   4
+
+              )pbdoc")
+         .def("number_of_rows",
+              &BMat8::number_of_rows,
+              R"pbdoc(
+                Returns the number of non-zero rows in ``self``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.number_of_rows()
+                   2
+               )pbdoc")
+         .def("is_regular_element",
+              &BMat8::is_regular_element,
+              R"pbdoc(
+                Check whether ``self`` is a regular element of the full boolean
+                matrix monoid of appropriate dimension.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.is_regular_element()
+                   True
+              )pbdoc")
+         .def("one",
+              &BMat8::one,  // py::arg("dim") = 8,
+              R"pbdoc(
+                This method returns the ``BMat8`` with the first ``dim`` entries
+                in the main diagonal equal to ``1`` and every other value equal
+                to ``0``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> BMat8.one(4)
+                   10000000
+                   01000000
+                   00100000
+                   00010000
+                   00000000
+                   00000000
+                   00000000
+                   00000000
+                   <BLANKLINE>
+              )pbdoc")
+         .def("__repr__", &detail::to_string<BMat8>)
+         .def("number_of_cols",
+              &bmat8_helpers::number_of_cols,
+              R"pbdoc(
+                Returns the number of non-zero columns in ``self``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.number_of_cols()
+                   2
+              )pbdoc")
+         .def("column_space_size",
+              &bmat8_helpers::col_space_size,
+              R"pbdoc(
+                Returns the size of the row space of ``self``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.column_space_size()
+                   4
+              )pbdoc")
+         .def("minimum_dim",
+              &bmat8_helpers::minimum_dim,
+              R"pbdoc(
+                This method returns the maximal ``i`` such that row ``i``
+                or column ``i`` contains a ``1``.
+
+                .. doctest::
+
+                   >>> from libsemigroups_pybind11 import BMat8
+                   >>> x = BMat8([[0, 1], [1, 0]])
+                   >>> x.minimum_dim()
+                   2
+              )pbdoc");
+   }
+ */
+}  // namespace libsemigroups

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1,0 +1,142 @@
+//
+// libsemigroups_pybind11
+// Copyright (C) 2022 Murray T. Whyte
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// C std headers....
+#include <stddef.h>  // for size_t
+#include <stdint.h>  // for int32_t, uint32_t
+
+// C++ stl headers....
+#include <initializer_list>  // for initializer_list
+#include <vector>            // for vector
+
+// libsemigroups....
+#include <libsemigroups/detail/string.hpp>    // for to_string
+#include <libsemigroups/fpsemi-examples.hpp>  // for monogenic_semigroup, ...
+#include <libsemigroups/presentation.hpp>     // for Presentation
+#include <libsemigroups/types.hpp>            // for word_type
+
+// pybind11....
+#include <pybind11/pybind11.h>  // for class_, init, module
+#include <pybind11/stl.h>
+
+// libsemigroups_pybind11....
+#include "main.hpp"  // for init_present
+
+namespace py = pybind11;
+namespace libsemigroups { /*
+   void init_fpsemi_examples(py::module& m) {
+     py::enum_<fpsemigroup::author>(m, "author")
+         .value("Machine", fpsemigroup::author::Machine)
+         .value("Aizenstat", fpsemigroup::author::Aizenstat)
+         .value("Burnside", fpsemigroup::author::Burnside)
+         .value("Carmichael", fpsemigroup::author::Carmichael)
+         .value("Coxeter", fpsemigroup::author::Coxeter)
+         .value("Easdown", fpsemigroup::author::Easdown)
+         .value("East", fpsemigroup::author::East)
+         .value("FitzGerald", fpsemigroup::author::FitzGerald)
+         .value("Godelle", fpsemigroup::author::Godelle)
+         .value("Guralnick", fpsemigroup::author::Guralnick)
+         .value("Iwahori", fpsemigroup::author::Iwahori)
+         .value("Kantor", fpsemigroup::author::Kantor)
+         .value("Kassabov", fpsemigroup::author::Kassabov)
+         .value("Lubotzky", fpsemigroup::author::Lubotzky)
+         .value("Miller", fpsemigroup::author::Miller)
+         .value("Moore", fpsemigroup::author::Moore)
+         .value("Moser", fpsemigroup::author::Moser)
+         .value("Sutov", fpsemigroup::author::Sutov)
+         .def("__add__", &fpsemigroup::operator+);
+
+     m.def("make_presentation", &fpsemigroup::make<Presentation<word_type>>)
+         .def("symmetric_group",
+              &fpsemigroup::symmetric_group,
+              py::arg("n").noconvert(),
+              py::arg("val") = fpsemigroup::author::Carmichael,
+              py::arg("index") = 0)
+         .def("alternating_group",
+              &fpsemigroup::alternating_group,
+              py::arg("n").noconvert(),
+              py::arg("val") = fpsemigroup::author::Moore)
+         .def("full_transformation_monoid",
+              &fpsemigroup::full_transformation_monoid,
+              py::arg("n").noconvert(),
+              py::arg("val") = fpsemigroup::author::Iwahori)
+         .def("partial_transformation_monoid",
+              &fpsemigroup::partial_transformation_monoid,
+              py::arg("n").noconvert(),
+              py::arg("val") = fpsemigroup::author::Sutov)
+         .def("symmetric_inverse_monoid",
+              &fpsemigroup::symmetric_inverse_monoid,
+              py::arg("n").noconvert(),
+              py::arg("val") = fpsemigroup::author::Sutov)
+         .def("dual_symmetric_inverse_monoid",
+              &fpsemigroup::dual_symmetric_inverse_monoid,
+              py::arg("n").noconvert(),
+              py::arg("val") = fpsemigroup::author::Easdown
+                               + fpsemigroup::author::East
+                               + fpsemigroup::author::FitzGerald)
+         .def("uniform_block_bijection_monoid",
+              &fpsemigroup::uniform_block_bijection_monoid,
+              py::arg("n").noconvert(),
+              py::arg("val") = fpsemigroup::author::FitzGerald)
+         .def("partition_monoid",
+              &fpsemigroup::partition_monoid,
+              py::arg("n").noconvert(),
+              py::arg("val") = fpsemigroup::author::East)
+         .def("brauer_monoid",
+              &fpsemigroup::brauer_monoid,
+              py::arg("n").noconvert())
+         .def("rectangular_band",
+              &fpsemigroup::rectangular_band,
+              py::arg("m").noconvert(),
+              py::arg("n").noconvert())
+         .def("stellar_monoid",
+              &fpsemigroup::stellar_monoid,
+              py::arg("n").noconvert())
+         .def("chinese_monoid",
+              &fpsemigroup::chinese_monoid,
+              py::arg("n").noconvert())
+         .def("monogenic_semigroup",
+              &fpsemigroup::monogenic_semigroup,
+              py::arg("m").noconvert(),
+              py::arg("r").noconvert())
+         .def("plactic_monoid",
+              &fpsemigroup::plactic_monoid,
+              py::arg("n").noconvert())
+         .def("stylic_monoid",
+              &fpsemigroup::stylic_monoid,
+              py::arg("l").noconvert())
+         .def("fibonacci_semigroup",
+              &fpsemigroup::fibonacci_semigroup,
+              py::arg("r").noconvert(),
+              py::arg("n").noconvert())
+         .def("temperley_lieb_monoid",
+              &fpsemigroup::temperley_lieb_monoid,
+              py::arg("n").noconvert())
+         .def("singular_brauer_monoid",
+              &fpsemigroup::singular_brauer_monoid,
+              py::arg("n").noconvert())
+         .def("orientation_preserving_monoid",
+              &fpsemigroup::orientation_preserving_monoid,
+              py::arg("n").noconvert())
+         .def("orientation_reversing_monoid",
+              &fpsemigroup::orientation_reversing_monoid,
+              py::arg("n").noconvert());
+   }
+ */
+}  // namespace libsemigroups
+   //

--- a/src/froidure-pin.cpp
+++ b/src/froidure-pin.cpp
@@ -1,0 +1,313 @@
+//
+// libsemigroups_pybind11
+// Copyright (C) 2021 James D. Mitchell
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// C std headers....
+#include <stddef.h>  // for size_t
+
+// C++ stl headers....
+#include <algorithm>         // for fill, copy
+#include <array>             // for array
+#include <chrono>            // for nanoseconds
+#include <cstdint>           // for uint16_t, uint32_t, uint8_t
+#include <functional>        // for __base, function
+#include <initializer_list>  // for initializer_list
+#include <memory>            // for allocator, shared_ptr
+#include <ostream>           // for operator<<, string, ostringstream
+#include <string>            // for char_traits, operator+, basic_st...
+#include <unordered_map>     // for operator==, operator!=
+#include <vector>            // for vector
+
+// libsemigroups....
+#include <libsemigroups/bipart.hpp>             // for Bipartition
+#include <libsemigroups/bmat8.hpp>              // for BMat8
+#include <libsemigroups/constants.hpp>          // for operator==
+#include <libsemigroups/detail/containers.hpp>  // for DynamicArray2
+#include <libsemigroups/detail/kbe.hpp>  // for KBE, FroidurePin<>::factorisation
+#include <libsemigroups/detail/tce.hpp>         // for TCE, TCE::Table
+#include <libsemigroups/froidure-pin-base.hpp>  // for FroidurePinBase
+#include <libsemigroups/froidure-pin.hpp>  // for FroidurePin<>::element_index_type
+#include <libsemigroups/matrix.hpp>  // for MaxPlusTruncMat, MinPlusTruncMat
+#include <libsemigroups/pbr.hpp>     // for PBR
+#include <libsemigroups/runner.hpp>  // for Runner
+#include <libsemigroups/transf.hpp>  // for PPerm, Transf, Perm, LeastPPerm
+#include <libsemigroups/types.hpp>   // for letter_type, word_type
+
+// pybind11....
+#include <pybind11/chrono.h>
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>  // for module, make_iterator, class_, init
+#include <pybind11/stl.h>       // for operator<<
+
+// libsemigroups_pybind11....
+#include "doc-strings.hpp"  // for dead, finished, kill, report
+#include "main.hpp"         // for init_froidure_pin
+
+namespace libsemigroups {
+  namespace fpsemigroup {
+    class KnuthBendix;
+  }
+}  // namespace libsemigroups
+
+namespace libsemigroups { /*
+   namespace {
+
+     template <typename T>
+     py::list convert(detail::DynamicArray2<T> const& da) {
+       py::list result;
+       for (size_t i = 0; i < da.number_of_rows(); ++i) {
+         py::list row;
+         for (size_t j = 0; j < da.number_of_cols(); ++j) {
+           row.append(da.get(i, j));
+         }
+         result.append(row);
+       }
+       return result;
+     }
+
+     template <typename T>
+     std::string froidure_pin_repr(T& fp) {
+       std::ostringstream out;
+       out << "FroidurePin([";
+       const auto  separator = ", ";
+       const auto* sep       = "";
+
+       for (size_t i = 0; i < fp.number_of_generators(); ++i) {
+         auto obj = py::cast(fp.generator(i));
+         out << sep << obj.attr("__repr__")();
+         sep = separator;
+       }
+       out << "])";
+       return out.str();
+     }
+
+     template <typename T, typename S = FroidurePinTraits<T>>
+     void bind_froidure_pin(py::module& m, std::string typestr) {
+       using Class              = FroidurePin<T, S>;
+       using element_type       = typename FroidurePin<T, S>::element_type;
+       using const_reference    = typename FroidurePin<T, S>::const_reference;
+       std::string pyclass_name = std::string("FroidurePin") + typestr;
+       py::class_<Class, std::shared_ptr<Class>, FroidurePinBase> x(
+           m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr());
+
+       x.attr("element_type") = m.attr(typestr.c_str());
+
+       x.def(py::init<std::vector<element_type> const&>(), py::arg("coll"))
+           .def(py::init<Class const&>(), py::arg("that"))
+           .def("size", &Class::size)
+           .def("add_generator", &Class::add_generator, py::arg("x"))
+           .def("number_of_generators", &Class::number_of_generators)
+           .def("batch_size",
+                py::overload_cast<size_t>(&Class::batch_size),
+                py::arg("val"))
+           .def("batch_size",
+                py::overload_cast<>(&Class::batch_size, py::const_))
+           .def("max_threads",
+                py::overload_cast<size_t>(&Class::max_threads),
+                py::arg("val"))
+           .def("max_threads",
+                py::overload_cast<>(&Class::max_threads, py::const_))
+           .def("concurrency_threshold",
+                py::overload_cast<size_t>(&Class::concurrency_threshold),
+                py::arg("thrshld"))
+           .def("concurrency_threshold",
+                py::overload_cast<>(&Class::concurrency_threshold, py::const_))
+           .def("reserve", &Class::reserve)
+           .def("immutable",
+                py::overload_cast<bool>(&Class::immutable),
+                py::arg("val"))
+           .def("immutable", py::overload_cast<>(&Class::immutable, py::const_))
+           .def("is_monoid", &Class::is_monoid)
+           .def("current_size", [](Class const& x) { return x.current_size(); })
+           .def("current_number_of_rules",
+                [](Class const& x) { return x.current_number_of_rules(); })
+           .def("enumerate", &FroidurePinBase::enumerate, py::arg("limit"))
+           .def("right_cayley_graph",
+                [](Class& x) { return convert(x.right_cayley_graph()); })
+           .def("left_cayley_graph",
+                [](Class& x) { return convert(x.left_cayley_graph()); })
+           .def("current_max_word_length",
+                [](Class const& x) { return x.current_max_word_length(); })
+           .def("current_position",
+                py::overload_cast<const_reference>(&Class::current_position,
+                                                   py::const_),
+                py::arg("x"))
+           .def("current_position",
+                py::overload_cast<word_type const&>(&Class::current_position,
+                                                    py::const_),
+                py::arg("w"))
+           .def("current_position",
+                py::overload_cast<letter_type>(&Class::current_position,
+                                               py::const_),
+                py::arg("i"))
+           .def("minimal_factorisation",
+                py::overload_cast<element_index_type>(
+                    &Class::minimal_factorisation),
+                py::arg("pos"))
+           .def("factorisation",
+                py::overload_cast<element_index_type>(&Class::factorisation),
+                py::arg("pos"))
+           .def("factorisation",
+                py::overload_cast<const_reference>(&Class::factorisation),
+                py::arg("x"))
+           .def("number_of_rules", &Class::number_of_rules)
+           .def("rules",
+                [](Class const& x) {
+                  return py::make_iterator(x.cbegin_rules(), x.cend_rules());
+                })
+           .def("current_length",
+                &FroidurePinBase::current_length,
+                py::arg("pos"))
+           .def("length", &FroidurePinBase::length, py::arg("pos"))
+           .def("product_by_reduction",
+                &FroidurePinBase::product_by_reduction,
+                py::arg("i"),
+                py::arg("j"))
+           .def("prefix", &FroidurePinBase::prefix, py::arg("pos"))
+           .def("suffix", &FroidurePinBase::suffix, py::arg("pos"))
+           .def("first_letter", &FroidurePinBase::first_letter, py::arg("pos"))
+           .def("final_letter", &FroidurePinBase::final_letter, py::arg("pos"))
+           .def("degree", [](Class const& x) { return x.degree(); })
+           .def("run", &Class::run, runner_doc_strings::run)
+           .def("run_for",
+                (void(Class::  // NOLINT(whitespace/parens)
+                          *)(std::chrono::nanoseconds))
+                    & Runner::run_for,
+                py::arg("t"),
+                runner_doc_strings::run_for)
+           .def("run_until",
+                (void(Class::  // NOLINT(whitespace/parens)
+                          *)(std::function<bool()>&))
+                    & Runner::run_until,
+                py::arg("func"),
+                runner_doc_strings::run_until)
+           .def("kill", &Class::kill, runner_doc_strings::kill)
+           .def("dead", &Class::dead, runner_doc_strings::dead)
+           .def("finished", &Class::finished, runner_doc_strings::finished)
+           .def("started", &Class::started, runner_doc_strings::started)
+           .def("report", &Class::report, runner_doc_strings::report)
+           .def("report_every",
+                (void(Class::  // NOLINT(whitespace/parens)
+                          *)(std::chrono::nanoseconds))
+                    & Runner::report_every,
+                py::arg("t"),
+                runner_doc_strings::report_every)
+           .def("report_why_we_stopped",
+                &Class::report_why_we_stopped,
+                runner_doc_strings::report_why_we_stopped)
+           .def(
+               "running",
+               [](Class const& x) { return x.running(); },
+               runner_doc_strings::running)
+           .def("timed_out", &Class::timed_out, runner_doc_strings::timed_out)
+           .def("stopped", &Class::stopped, runner_doc_strings::stopped)
+           .def("stopped_by_predicate",
+                &Class::stopped_by_predicate,
+                runner_doc_strings::stopped_by_predicate)
+           .def(
+               "add_generators",
+               [](Class& x, std::vector<element_type> const& y) {
+                 x.add_generators(y);
+               },
+               py::arg("coll"))
+           .def(
+               "closure",
+               [](Class& x, std::vector<element_type> const& y) {
+                 x.closure(y);
+               },
+               py::arg("coll"))
+           .def(
+               "copy_add_generators",
+               [](Class& x, std::vector<element_type> const& y) {
+                 return x.copy_add_generators(y);
+               },
+               py::arg("coll"))
+           .def(
+               "copy_closure",
+               [](Class& x, std::vector<element_type> const& y) {
+                 return x.copy_closure(y);
+               },
+               py::arg("coll"))
+           .def("word_to_element", &Class::word_to_element, py::arg("w"))
+           .def("generator", &Class::generator, py::arg("i"))
+           .def("contains", &Class::contains, py::arg("x"))
+           .def("sorted_position", &Class::sorted_position, py::arg("x"))
+           .def("position", &Class::position, py::arg("x"))
+           .def("sorted_at", &Class::sorted_at, py::arg("i"))
+           .def("at", &Class::at, py::arg("i"))
+           .def("__iter__",
+                [](Class const& x) {
+                  return py::make_iterator(x.cbegin(), x.cend());
+                })
+           .def("sorted",
+                [](Class& x) {
+                  return py::make_iterator(x.cbegin_sorted(), x.cend_sorted());
+                })
+           .def("idempotents",
+                [](Class& x) {
+                  return py::make_iterator(x.cbegin_idempotents(),
+                                           x.cend_idempotents());
+                })
+           .def("number_of_idempotents", &Class::number_of_idempotents)
+           .def("is_idempotent", &Class::is_idempotent, py::arg("i"))
+           .def("position_to_sorted_position",
+                &Class::position_to_sorted_position,
+                py::arg("i"))
+           .def("is_finite", &Class::is_finite)
+           .def("equal_to", &Class::equal_to, py::arg("x"), py::arg("y"))
+           .def("fast_product", &Class::fast_product, py::arg("i"),
+   py::arg("j")) .def("__repr__", &froidure_pin_repr<Class>);
+     }
+   }  // namespace
+
+   void init_froidure_pin(py::module& m) {
+     py::class_<FroidurePinBase, std::shared_ptr<FroidurePinBase>>(
+         m, "FroidurePinBase");
+
+     bind_froidure_pin<LeastTransf<16>>(m, "Transf16");
+     bind_froidure_pin<Transf<0, uint8_t>>(m, "Transf1");
+     bind_froidure_pin<Transf<0, uint16_t>>(m, "Transf2");
+     bind_froidure_pin<Transf<0, uint32_t>>(m, "Transf4");
+     bind_froidure_pin<LeastPPerm<16>>(m, "PPerm16");
+     bind_froidure_pin<PPerm<0, uint8_t>>(m, "PPerm1");
+     bind_froidure_pin<PPerm<0, uint16_t>>(m, "PPerm2");
+     bind_froidure_pin<PPerm<0, uint32_t>>(m, "PPerm4");
+     bind_froidure_pin<LeastPerm<16>>(m, "Perm16");
+     bind_froidure_pin<Perm<0, uint8_t>>(m, "Perm1");
+     bind_froidure_pin<Perm<0, uint16_t>>(m, "Perm2");
+     bind_froidure_pin<Perm<0, uint32_t>>(m, "Perm4");
+     bind_froidure_pin<detail::KBE,
+                       FroidurePinTraits<detail::KBE,
+   fpsemigroup::KnuthBendix>>( m, "KBE"); bind_froidure_pin<detail::TCE,
+                       FroidurePinTraits<detail::TCE, detail::TCE::Table>>(
+         m, "TCE");
+     bind_froidure_pin<Bipartition>(m, "Bipartition");
+     bind_froidure_pin<PBR>(m, "PBR");
+
+     bind_froidure_pin<BMat8>(m, "BMat8");
+     bind_froidure_pin<BMat<>>(m, "BMat");
+     bind_froidure_pin<IntMat<>>(m, "IntMat");
+     bind_froidure_pin<MaxPlusMat<>>(m, "MaxPlusMat");
+     bind_froidure_pin<MinPlusMat<>>(m, "MinPlusMat");
+     bind_froidure_pin<ProjMaxPlusMat<>>(m, "ProjMaxPlusMat");
+     bind_froidure_pin<MaxPlusTruncMat<>>(m, "MaxPlusTruncMat");
+     bind_froidure_pin<MinPlusTruncMat<>>(m, "MinPlusTruncMat");
+     bind_froidure_pin<NTPMat<>>(m, "NTPMat");
+   }
+   */
+}  // namespace libsemigroups
+   //

--- a/src/kambites.cpp
+++ b/src/kambites.cpp
@@ -1,0 +1,495 @@
+//
+// libsemigroups_pybind11
+// Copyright (C) 2022 James D. Mitchell
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// C std headers....
+// C++ stl headers....
+
+// libsemigroups....
+#include <libsemigroups/kambites.hpp>  // for Kambites
+#include <libsemigroups/types.hpp>     // for rule_type
+
+// pybind11....
+#include <pybind11/pybind11.h>  // for class_, init, module
+#include <pybind11/stl.h>
+
+// libsemigroups_pybind11....
+#include "doc-strings.hpp"  // for init_kambites
+#include "main.hpp"         // for init_kambites
+
+namespace py = pybind11;
+
+namespace libsemigroups { /*
+   void init_kambites(py::module& m) {
+     using detail::MultiStringView;
+     using string_type =
+         typename fpsemigroup::Kambites<MultiStringView>::string_type;
+
+     py::class_<fpsemigroup::Kambites<MultiStringView>> k(m, "Kambites");
+
+     k.def(py::init<>())
+         .def(py::init<fpsemigroup::Kambites<MultiStringView> const&>())
+         .def("small_overlap_class",
+              &fpsemigroup::Kambites<MultiStringView>::small_overlap_class,
+              R"pbdoc(
+                Get the small overlap class.
+
+                :return:
+                  The greatest positive integer :math:`n` such that the finitely
+                  semigroup represented by this satisfies the condition
+                  :math:`C(n)`; or :py:obj:`POSITIVE_INFINITY` if no word
+                  occurring in a relation can be written as a product of pieces.
+              )pbdoc")
+         .def("number_of_pieces",
+              &fpsemigroup::Kambites<MultiStringView>::number_of_pieces,
+              py::arg("i"),
+              R"pbdoc(
+                Returns the minimum number of pieces required to factorise the
+                :math:`i`-th relation word.
+
+                :param i: the index of the relation word
+                :type i: int
+
+                :return: An ``int``.
+              )pbdoc")
+         .def("number_of_normal_forms",
+              &fpsemigroup::Kambites<MultiStringView>::number_of_normal_forms,
+              py::arg("min"),
+              py::arg("max"),
+              R"pbdoc(
+                Returns the number of normal forms with length in a given range.
+
+                :param min: the minimum length of a normal form to count
+                :type min: int
+                :param max: one larger than the maximum length of a normal form
+   to count. :type max: int
+
+                :return: An ``int``.
+              )pbdoc")
+         .def("uint_to_char",
+              &fpsemigroup::Kambites<MultiStringView>::uint_to_char,
+              py::arg("a"),
+              R"pbdoc(
+                Convert a ``int`` to a ``char``.
+
+                :param a: the letter to convert.
+                :type a: int
+
+                :return: A ``char``.
+              )pbdoc")
+         .def("char_to_uint",
+              &fpsemigroup::Kambites<MultiStringView>::char_to_uint,
+              py::arg("a"),
+              R"pbdoc(
+                Convert a ``char`` to a ``letter_type``.
+
+                :param a: the string to convert.
+                :type a: str
+
+                :return: An ``int``.
+              )pbdoc")
+         .def("string_to_word",
+              &fpsemigroup::Kambites<MultiStringView>::string_to_word,
+              py::arg("w"),
+              R"pbdoc(
+                Convert a string to a word.
+
+                :param w: the string to convert.
+                :type w: str
+
+                :return: A  ``List[int]``.
+              )pbdoc")
+         .def("is_obviously_finite",
+              &fpsemigroup::Kambites<MultiStringView>::is_obviously_finite,
+              R"pbdoc(
+                Check if the finitely presented semigroup is obviously finite.
+
+                :return: A ``bool``.
+              )pbdoc")
+         .def("word_to_string",
+              &fpsemigroup::Kambites<MultiStringView>::word_to_string,
+              py::arg("w"),
+              R"pbdoc(
+                Convert a ``List[int]`` to a ``str``.
+
+                :param w: the word to convert.
+                :type w: List[int]
+
+                :return: A string.
+              )pbdoc")
+         .def("is_obviously_infinite",
+              &fpsemigroup::Kambites<MultiStringView>::is_obviously_infinite,
+              R"pbdoc(
+                Check if the finitely presented semigroup is obviously infinite.
+
+                :return: A ``bool``.
+              )pbdoc")
+         .def("size",
+              &fpsemigroup::Kambites<MultiStringView>::size,
+              R"pbdoc(
+                Returns the size of the finitely presented semigroup or
+                :py:obj:`POSITIVE_INFINITY`.
+
+                :return: An ``int``.
+              )pbdoc")
+         .def(
+             "rules",
+             [](fpsemigroup::Kambites<MultiStringView> const& k) {
+               return py::make_iterator(k.cbegin_rules(), k.cend_rules());
+             },
+             R"pbdoc(
+               Returns an iterator to the rules.
+             )pbdoc")
+         .def("alphabet",
+              py::overload_cast<size_t>(
+                  &fpsemigroup::Kambites<MultiStringView>::alphabet,
+   py::const_), py::arg("i"), R"pbdoc( Returns the ith letter of the alphabet.
+
+                :Parameters: **i** (int) - the index of the letter.
+
+                :Returns: A string.
+              )pbdoc")
+         .def("alphabet",
+              py::overload_cast<>(
+                  &fpsemigroup::Kambites<MultiStringView>::alphabet,
+   py::const_), R"pbdoc( Returns the alphabet.
+
+                :Returns: A string.
+              )pbdoc")
+         .def("identity",
+              &fpsemigroup::Kambites<MultiStringView>::identity,
+              R"pbdoc(
+                Returns the identity (if any).
+
+                :return: A string.
+              )pbdoc")
+         .def("set_identity",
+              py::overload_cast<letter_type>(
+                  &fpsemigroup::Kambites<MultiStringView>::set_identity),
+              py::arg("id"),
+              R"pbdoc(
+                Set a character in alphabet() to be the identity using its
+   index.
+
+                :Parameters:
+                  **id** (int) - the index of the character to be the identity.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("inverses",
+              &fpsemigroup::Kambites<MultiStringView>::inverses,
+              R"pbdoc(
+                Returns the inverses (if any).
+
+                :return: A string.
+              )pbdoc")
+         .def("number_of_rules",
+              &fpsemigroup::Kambites<MultiStringView>::number_of_rules,
+              R"pbdoc(
+                Returns the number of rules.
+
+                :return: An ``int``.
+              )pbdoc")
+         .def("add_rule",
+              py::overload_cast<relation_type>(
+                  &fpsemigroup::Kambites<MultiStringView>::add_rule),
+              py::arg("rel"),
+              R"pbdoc(
+                Add a rule using a tuple of lists of ints.
+
+                :Parameters: **rel** (Tuple[List[int], List[int]]) - the rule
+   being added.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("add_rule",
+              py::overload_cast<std::string const&, std::string const&>(
+                  &fpsemigroup::Kambites<MultiStringView>::add_rule),
+              py::arg("u"),
+              py::arg("v"),
+              R"pbdoc(
+                Add a rule using strings.
+
+                :Parameters: - **u** (str) - the left-hand side of the rule
+   being added.
+                             - **v** (str) - the right-hand side of the rule
+   being added.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("add_rule",
+              py::overload_cast<word_type const&, word_type const&>(
+                  &fpsemigroup::Kambites<MultiStringView>::add_rule),
+              py::arg("u"),
+              py::arg("v"),
+              R"pbdoc(
+                Add a rule using two word_type const references.
+
+                :Parameters: - **u** (List[int]) - the left-hand side of the
+   rule being added.
+                             - **v** (List[int]) - the right-hand side of the
+   rule being added.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("add_rules",
+              py::overload_cast<FroidurePinBase&>(
+                  &fpsemigroup::Kambites<MultiStringView>::add_rules),
+              py::arg("S"),
+              R"pbdoc(
+                Add rules from a :py:obj:`FroidurePin` instance.
+
+                :Parameters:
+                  **S** (FroidurePin) - a :py:obj:`FroidurePin` object
+                  representing a semigroup.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("has_froidure_pin",
+              &fpsemigroup::Kambites<MultiStringView>::has_froidure_pin,
+              R"pbdoc(
+                Check if an isomorphic :py:obj:`FroidurePin` instance is known.
+
+                :return: A bool.
+              )pbdoc")
+         .def("froidure_pin",
+              &fpsemigroup::Kambites<MultiStringView>::froidure_pin,
+              R"pbdoc(
+                Returns an isomorphic :py:obj:`FroidurePin` instance.
+
+                :return: A :py:obj:`FroidurePinBase`.
+              )pbdoc")
+         .def("set_alphabet",
+              py::overload_cast<size_t>(
+                  &fpsemigroup::Kambites<MultiStringView>::set_alphabet),
+              py::arg("n"),
+              R"pbdoc(
+                Set the size of the alphabet.
+
+                :Parameters: **n** (int) - the number of letters.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("set_alphabet",
+              py::overload_cast<std::string const&>(
+                  &fpsemigroup::Kambites<MultiStringView>::set_alphabet),
+              py::arg("a"),
+              R"pbdoc(
+                Set the alphabet of the finitely presented semigroup.
+
+                :Parameters: **a** (str) - the alphabet.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("set_identity",
+              py::overload_cast<std::string const&>(
+                  &fpsemigroup::Kambites<MultiStringView>::set_identity),
+              py::arg("id"),
+              R"pbdoc(
+                Set a character in alphabet() to be the identity.
+
+                :Parameters:
+                  **id** (str) - a string containing the character to be the
+                  identity.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("set_inverses",
+              &fpsemigroup::Kambites<MultiStringView>::set_inverses,
+              py::arg("a"),
+              R"pbdoc(
+                Set the inverses of letters in :py:meth:`~Kambites.alphabet()`.
+
+                :param a: a string of length
+   :py:meth:`len(~Kambites.alphabet())``. :type a: str
+
+                :return: (None)
+              )pbdoc")
+         .def("validate_letter",
+              py::overload_cast<char>(
+                  &fpsemigroup::Kambites<MultiStringView>::validate_letter,
+                  py::const_),
+              py::arg("c"),
+              R"pbdoc(
+                Validates a letter specified by a string.
+
+                :Parameters: **c** (str) - the letter to validate.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("validate_letter",
+              py::overload_cast<letter_type>(
+                  &fpsemigroup::Kambites<MultiStringView>::validate_letter,
+                  py::const_),
+              py::arg("c"),
+              R"pbdoc(
+                Validates a letter specified by an integer.
+
+                :Parameters: **c** (int) - the letter to validate.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("validate_word",
+              py::overload_cast<word_type const&>(
+                  &fpsemigroup::Kambites<MultiStringView>::validate_word,
+                  py::const_),
+              py::arg("w"),
+              R"pbdoc(
+                Validates a word given by a ``List[int]``.
+
+                :Parameters: **w** (List[int]) - the word to validate.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("validate_word",
+              py::overload_cast<std::string const&>(
+                  &fpsemigroup::Kambites<MultiStringView>::validate_word,
+                  py::const_),
+              py::arg("w"),
+              R"pbdoc(
+                Validates a word given by a string.
+
+                :Parameters: **w** (str) - the word to validate.
+
+                :Returns: (None)
+              )pbdoc")
+         .def("normal_form",
+              py::overload_cast<string_type const&>(
+                  &fpsemigroup::Kambites<MultiStringView>::normal_form),
+              py::arg("w"),
+              R"pbdoc(
+                Returns a normal form for a string.
+
+                :Parameters: **w** (str) - the word whose normal form we want to
+   find.
+
+                :Returns: A ``str``.
+              )pbdoc")
+         .def("normal_form",
+              py::overload_cast<word_type const&>(
+                  &FpSemigroupInterface::normal_form),
+              py::arg("w"),
+              R"pbdoc(
+                Returns a normal form for a word_type.
+
+                :Parameters:
+                  **w** (List[int]) - the word whose normal form we want to
+   find.
+
+                :Returns:
+                   The normal form of the parameter ``w``, a value of type
+                   ``List[int]``.
+              )pbdoc")
+         .def("equal_to",
+              py::overload_cast<string_type const&, string_type const&>(
+                  &fpsemigroup::Kambites<MultiStringView>::equal_to),
+              py::arg("u"),
+              py::arg("v"),
+              R"pbdoc(
+                Check if two words represent the same element.
+
+                :Parameters:
+                   - **u** (str) - first word for comparison.
+                   - **v** (str) - second word for comparison.
+
+                :Returns:
+                  ``True`` if the strings ``u`` and ``v`` represent the same
+                  element of the finitely presented semigroup, and ``False``
+                  otherwise.
+              )pbdoc")
+         .def("equal_to",
+              py::overload_cast<word_type const&, word_type const&>(
+                  &fpsemigroup::Kambites<MultiStringView>::equal_to),
+              py::arg("u"),
+              py::arg("v"),
+              R"pbdoc(
+                Check if two words represent the same element.
+
+                :Parameters: - **u** (List[int]) - first word for comparison.
+                             - **v** (List[int]) - second word for comparison.
+
+                :Returns:
+                  ``True`` if the words ``u`` and ``v`` represent the same
+                  element of the finitely presented semigroup, and ``False``
+                  otherwise.
+              )pbdoc")
+         .def("has_identity",
+              &fpsemigroup::Kambites<MultiStringView>::has_identity,
+              R"pbdoc(
+                Check if an identity has been set.
+
+                :return: A ``bool``.
+              )pbdoc")
+         .def("ukkonen",
+              &fpsemigroup::Kambites<MultiStringView>::ukkonen,
+              R"pbdoc(
+              TODO
+              )pbdoc")
+         .def("dead",
+              &fpsemigroup::Kambites<MultiStringView>::dead,
+              runner_doc_strings::dead)
+         .def("finished",
+              &fpsemigroup::Kambites<MultiStringView>::finished,
+              runner_doc_strings::finished)
+         .def("started",
+              &fpsemigroup::Kambites<MultiStringView>::started,
+              runner_doc_strings::started)
+         .def("stopped",
+              &fpsemigroup::Kambites<MultiStringView>::stopped,
+              runner_doc_strings::stopped)
+         .def("timed_out",
+              &fpsemigroup::Kambites<MultiStringView>::timed_out,
+              runner_doc_strings::timed_out)
+         .def("running",
+              &fpsemigroup::Kambites<MultiStringView>::running,
+              runner_doc_strings::running)
+         .def("stopped_by_predicate",
+              &fpsemigroup::Kambites<MultiStringView>::stopped_by_predicate,
+              runner_doc_strings::stopped_by_predicate)
+         .def("kill",
+              &fpsemigroup::Kambites<MultiStringView>::kill,
+              runner_doc_strings::kill)
+         .def("run",
+              &fpsemigroup::Kambites<MultiStringView>::run,
+              runner_doc_strings::run)
+         .def("run_for",
+              (void(fpsemigroup::Kambites<  // NOLINT(whitespace/parens)
+                    MultiStringView>::*)(std::chrono::nanoseconds))
+                  & Runner::run_for,
+              py::arg("t"),
+              runner_doc_strings::run_for)
+         .def("run_until",
+              (void(fpsemigroup::Kambites<  // NOLINT(whitespace/parens)
+                    MultiStringView>::*)(std::function<bool()>&))
+                  & Runner::run_until,
+              py::arg("func"),
+              runner_doc_strings::run_until)
+         .def("report_every",
+              (void(fpsemigroup::Kambites<  // NOLINT(whitespace/parens)
+                    MultiStringView>::*)(std::chrono::nanoseconds))
+                  & Runner::report_every,
+              py::arg("t"),
+              runner_doc_strings::report_every)
+         .def("report",
+              &fpsemigroup::Kambites<MultiStringView>::report,
+              runner_doc_strings::report)
+         .def("report_why_we_stopped",
+              &fpsemigroup::Kambites<MultiStringView>::report_why_we_stopped,
+              runner_doc_strings::report_why_we_stopped);
+   }
+ */
+}  // namespace libsemigroups

--- a/src/konieczny.cpp
+++ b/src/konieczny.cpp
@@ -1,0 +1,207 @@
+//
+// libsemigroups_pybind11
+// Copyright (C) 2022 James D. Mitchell
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// C std headers....
+// C++ stl headers....
+// libsemigroups....
+#include <libsemigroups/bmat.hpp>       // for ImageRightAction
+#include <libsemigroups/bmat8.hpp>      // for BMat8
+#include <libsemigroups/konieczny.hpp>  // for Kambites
+#include <libsemigroups/matrix.hpp>     // for BMat
+#include <libsemigroups/transf.hpp>     // for PPerm, Transf, Perm, LeastPPerm
+
+// pybind11....
+#include <pybind11/chrono.h>      // for auto conversion into run_for
+#include <pybind11/functional.h>  // for auto conversion for run_until
+#include <pybind11/pybind11.h>    // for class_, init, module
+#include <pybind11/stl.h>
+
+// libsemigroups_pybind11....
+#include "main.hpp"  // for init_konieczny
+
+namespace py = pybind11;
+
+namespace libsemigroups { /*
+
+   template <typename T, typename S = KoniecznyTraits<T>>
+   void bind_konieczny(py::module& m, std::string typestr) {
+     using Konieczny_         = Konieczny<T, S>;
+     using DClass             = typename Konieczny_::DClass;
+     using element_type       = typename Konieczny<T, S>::element_type;
+     using const_reference    = typename Konieczny<T, S>::const_reference;
+     std::string pyclass_name = std::string("Konieczny") + typestr;
+
+     py::class_<Konieczny_> x(
+         m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr());
+
+     x.attr("element_type") = m.attr(typestr.c_str());
+     x.def(py::init<std::vector<element_type> const&>())
+         .def("add_generator", &Konieczny_::add_generator)
+         .def("contains", &Konieczny_::contains)
+         .def("__contains__", &Konieczny_::contains, py::is_operator())
+         .def("size", &Konieczny_::size)
+         .def("is_regular_element", &Konieczny_::is_regular_element)
+         .def("D_class_of_element",
+              &Konieczny_::D_class_of_element,
+              py::return_value_policy::reference_internal)
+         .def("D_classes",
+              [](Konieczny_ const& k) {
+                return py::make_iterator(k.cbegin_D_classes(),
+                                         k.cend_D_classes());
+              })
+         .def("regular_D_classes",
+              [](Konieczny_ const& k) {
+                return py::make_iterator(k.cbegin_regular_D_classes(),
+                                         k.cend_regular_D_classes());
+              })
+         .def("number_of_D_classes", &Konieczny_::number_of_D_classes)
+         .def("number_of_L_classes", &Konieczny_::number_of_L_classes)
+         .def("number_of_R_classes", &Konieczny_::number_of_R_classes)
+         .def("number_of_H_classes", &Konieczny_::number_of_H_classes)
+         .def("number_of_regular_D_classes",
+              &Konieczny_::number_of_regular_D_classes)
+         .def("number_of_regular_L_classes",
+              &Konieczny_::number_of_regular_L_classes)
+         .def("number_of_regular_R_classes",
+              &Konieczny_::number_of_regular_R_classes)
+         .def("number_of_regular_elements",
+              &Konieczny_::number_of_regular_elements)
+         .def("current_number_of_D_classes",
+              &Konieczny_::current_number_of_D_classes)
+         .def("current_number_of_L_classes",
+              &Konieczny_::current_number_of_L_classes)
+         .def("current_number_of_R_classes",
+              &Konieczny_::current_number_of_R_classes)
+         .def("current_number_of_H_classes",
+              &Konieczny_::current_number_of_H_classes)
+         .def("current_number_of_regular_D_classes",
+              &Konieczny_::current_number_of_regular_D_classes)
+         .def("current_number_of_regular_L_classes",
+              &Konieczny_::current_number_of_regular_L_classes)
+         .def("current_number_of_regular_R_classes",
+              &Konieczny_::current_number_of_regular_R_classes)
+         .def("current_number_of_regular_elements",
+              &Konieczny_::current_number_of_regular_elements)
+         .def("number_of_idempotents", &Konieczny_::number_of_idempotents)
+         .def("generator", &Konieczny_::generator)
+         .def("number_of_generators", &Konieczny_::number_of_generators)
+         .def("degree", &Konieczny_::degree)
+         .def("current_size", &Konieczny_::current_size)
+         .def("current_number_of_idempotents",
+              &Konieczny_::current_number_of_idempotents)
+         .def("generators",
+              [](Konieczny_ const& k) {
+                return py::make_iterator(k.cbegin_generators(),
+                                         k.cend_generators());
+              })
+         .def("dead", &Konieczny_::dead)
+         .def("finished", &Konieczny_::finished)
+         .def("started", &Konieczny_::started)
+         .def("stopped", &Konieczny_::stopped)
+         .def("timed_out", &Konieczny_::timed_out)
+         .def("running", &Konieczny_::running)
+         .def("stopped_by_predicate", &Konieczny_::stopped_by_predicate)
+         .def("kill", &Konieczny_::kill)
+         .def("run", &Konieczny_::run)
+         .def("run_for",
+              (void(Konieczny_::*)(std::chrono::nanoseconds)) & Runner::run_for)
+         .def("run_until",
+              (void(Konieczny_::*)(std::function<bool()>&)) & Runner::run_until)
+         .def("report_every",
+              (void(Konieczny_::*)(std::chrono::nanoseconds))
+                  & Runner::report_every)
+         .def("report_every",
+              (void(Konieczny_::*)(std::chrono::nanoseconds))
+                  & Runner::report_every)
+         .def("report", &Konieczny_::report)
+         .def("report_why_we_stopped", &Konieczny_::report_why_we_stopped)
+         .def("running_for", &Konieczny_::running_for)
+         .def("running_until", &Konieczny_::running_until);
+
+     py::class_<DClass> d(m, (pyclass_name + "DClass").c_str());
+
+     d.def("rep",
+           &DClass::rep,
+           R"pbdoc(
+                    Returns a representative of the $\mathscr{D}$-class.
+
+                    :return: A const_reference.
+                    )pbdoc")
+         .def("is_regular_D_class",
+              &DClass::is_regular_D_class,
+              R"pbdoc(
+              Test regularity of a $\mathscr{D}$-class.
+
+              :return: A value of type size_t.
+              )pbdoc")
+         .def("number_of_idempotents",
+              &DClass::number_of_idempotents,
+              R"pbdoc(
+              Returns the number of idempotents.
+
+              )pbdoc")
+         .def("number_of_L_classes",
+              &DClass::number_of_L_classes,
+              R"pbdoc(
+              Returns the number of $\mathscr{L}$-classes.
+
+              :return: A value of type size_t.
+              )pbdoc")
+         .def("number_of_R_classes",
+              &DClass::number_of_R_classes,
+              R"pbdoc(
+              Returns the number of $\mathscr{R}$-classes.
+
+              :return: A value of type size_t.
+              )pbdoc")
+         .def("size",
+              &DClass::size,
+              R"pbdoc(
+              Returns the size of a $\mathscr{D}$-class.
+
+              :return: A value of type size_t.
+              )pbdoc")
+         .def("size_H_class",
+              &DClass::size_H_class,
+              R"pbdoc(
+              Returns the size of the $\mathscr{H}$-classes.
+
+              :return: A value of type size_t.
+              )pbdoc")
+         .def("__contains__",
+              py::overload_cast<const_reference>(&DClass::contains),
+              py::is_operator())
+         .def("contains",
+              py::overload_cast<const_reference>(&DClass::contains),
+              py::arg("x"));
+   }
+
+   void init_konieczny(py::module& m) {
+     bind_konieczny<LeastTransf<16>>(m, "Transf16");
+     bind_konieczny<Transf<0, uint8_t>>(m, "Transf1");
+     bind_konieczny<Transf<0, uint16_t>>(m, "Transf2");
+     bind_konieczny<Transf<0, uint32_t>>(m, "Transf4");
+     bind_konieczny<LeastPPerm<16>>(m, "PPerm16");
+     bind_konieczny<PPerm<0, uint8_t>>(m, "PPerm1");
+     bind_konieczny<PPerm<0, uint16_t>>(m, "PPerm2");
+     bind_konieczny<PPerm<0, uint32_t>>(m, "PPerm4");
+     bind_konieczny<BMat8>(m, "BMat8");
+     bind_konieczny<BMat<>>(m, "BMat");
+   }
+   */
+}  // namespace libsemigroups

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -27,12 +27,10 @@ namespace libsemigroups {
 
   void init_forest(py::module&);
   void init_gabow(py::module&);
-  void init_knuth_bendix(py::module&);
   void init_order(py::module&);
   void init_paths(py::module&);
   void init_present(py::module&);
   void init_transf(py::module&);
-  void init_words(py::module&);
   void init_word_graph(py::module&);
 
   /*
@@ -45,6 +43,7 @@ namespace libsemigroups {
   void init_froidure_pin(py::module&);
   void init_kambites(py::module&);
   void init_konieczny(py::module&);
+  void init_knuth_bendix(py::module&);
   void init_matrix(py::module&);
   void init_pbr(py::module&);
   void init_present(py::module&);
@@ -53,6 +52,7 @@ namespace libsemigroups {
   void init_todd_coxeter(py::module&);
   void init_transf(py::module&);
   void init_ukkonen(py::module&);
+  void init_words(py::module&);
 */
 }  // namespace libsemigroups
 

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -30,7 +30,7 @@
 // libsemigroups....
 #include <libsemigroups/froidure-pin-base.hpp>  // for FroidurePinBase
 #include <libsemigroups/presentation.hpp>       // for Presentation
-#include <libsemigroups/to-presentation.hpp>    // for make
+#include <libsemigroups/to-presentation.hpp>    // for to_presentation
 
 // pybind11....
 #include <pybind11/pybind11.h>  // for class_, init, module
@@ -87,11 +87,13 @@ namespace libsemigroups {
           .def("validate", &Presentation<T>::validate)
           .def("__repr__", &presentation_repr<T>);
 
-      m.def("add_rule", &presentation::add_rule<T>);
-      m.def("add_rule_no_checks", &presentation::add_rule_no_checks<T>);
-      m.def("add_rules",
-            py::overload_cast<Presentation<T>&, Presentation<T> const&>(
-                &presentation::add_rules_no_checks<T>));
+      m.def("add_rule", [](Presentation<T>& p, T lhs, T rhs) {
+        return presentation::add_rule(p, lhs, rhs);
+      });
+      m.def("add_rule_no_checks", [](Presentation<T>& p, T lhs, T rhs) {
+        return presentation::add_rule(p, lhs, rhs);
+      });
+      m.def("add_rules", &presentation::add_rules<T>);
       m.def("add_identity_rules", &presentation::add_identity_rules<T>);
       m.def("add_zero_rules", &presentation::add_zero_rules<T>);
       // There are two definitions here to handle the default parameters
@@ -117,8 +119,8 @@ namespace libsemigroups {
             });
       m.def(
           "replace_subword",
-          [](Presentation<T>& p, T const& existing, T const& replace) -> void {
-            presentation::replace_subword(p, existing, replace);
+          [](Presentation<T>& p, T const& existing, T const& replace) -> void
+      { presentation::replace_subword(p, existing, replace);
           });
       m.def("replace_word", &presentation::replace_word<T>);
       m.def("length", [](Presentation<T> const& p) -> size_t {
@@ -140,7 +142,8 @@ namespace libsemigroups {
         return presentation::longest_rule_length(p);
       });
       m.def("shortest_rule", [](Presentation<T> const& p) {
-        return std::distance(p.rules.cbegin(), presentation::shortest_rule(p));
+        return std::distance(p.rules.cbegin(),
+      presentation::shortest_rule(p));
       });
       m.def("shortest_rule_length", [](Presentation<T> const& p) {
         return presentation::shortest_rule_length(p);
@@ -151,21 +154,20 @@ namespace libsemigroups {
             py::overload_cast<FroidurePinBase&>(to_presentation<word_type>));
 
       m.def("to_presentation",
-            [](Presentation<std::string> const& p) -> Presentation<word_type> {
-              return to_presentation<word_type>(p);
+            [](Presentation<std::string> const& p) -> Presentation<word_type>
+      { return to_presentation<word_type>(p);
             });
 
       m.def("to_presentation",
-            [](Presentation<word_type> const& p) -> Presentation<std::string> {
-              return to_presentation<std::string>(p);
+            [](Presentation<word_type> const& p) -> Presentation<std::string>
+      { return to_presentation<std::string>(p);
             });
 
-      // m.def("to_presentation",
-      //       [](Presentation<word_type> const& p,
-      //          std::string const&             s) -> Presentation<std::string>
-      //          {
-      //         return to_presentation<std::string>(p, s);
-      //       });
+      m.def("to_presentation",
+            [](Presentation<word_type> const& p,
+               std::string const&             s) -> Presentation<std::string>
+      { return to_presentation<std::string>(p, s);
+            });
       m.def("is_strongly_compressible",
             &presentation::is_strongly_compressible<T>);
       m.def("strongly_compress", &presentation::strongly_compress<T>);
@@ -173,6 +175,7 @@ namespace libsemigroups {
             &presentation::reduce_to_2_generators<T>,
             py::arg("p"),
             py::arg("index") = 0);
+            */
     }
   }  // namespace
 

--- a/src/word-graph.cpp
+++ b/src/word-graph.cpp
@@ -309,6 +309,7 @@ namespace libsemigroups {
               :type nr_nodes: int
               :param out_degree: the maximum out-degree of every node
               :type out_degree: int
+
               :returns: A ``WordGraph``.
             )pbdoc")
         .def_static(
@@ -330,6 +331,7 @@ namespace libsemigroups {
               :type out_degree: int
               :param nr_edges: the out-degree of every node
               :type nr_edges: int
+
               :returns: A ``WordGraph``.
             )pbdoc");
 

--- a/tests/test_gabow.py
+++ b/tests/test_gabow.py
@@ -1,0 +1,494 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2023, M. T. Whyte
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+
+"""
+This file contains tests for WordGraph and related functionality in
+libsemigroups_pybind11.
+"""
+
+# pylint: disable=no-name-in-module, missing-function-docstring, invalid-name,
+# pylint: disable=duplicate-code, too-many-lines
+
+import pytest
+
+from libsemigroups_pybind11 import (
+    POSITIVE_INFINITY,
+    UNDEFINED,
+    Gabow,
+    WordGraph,
+    word_graph,
+)
+
+
+def test_001():
+    g = WordGraph(17, 31)
+    for i in range(17):
+        g.number_of_scc()
+
+        for j in range(31):
+            g.add_edge(i, (7 * i + 23 * j) % 17, j)
+
+    assert g.number_of_edges() == 31 * 17
+    assert g.number_of_nodes() == 17
+    with pytest.raises(RuntimeError):
+        g.add_edge(0, 0, 32)
+    for i in range(17):
+        for j in range(31):
+            assert g.neighbor(i, j) == (7 * i + 23 * j) % 17
+
+    g.add_to_out_degree(10)
+    assert g.out_degree() == 41
+    assert g.number_of_nodes() == 17
+    assert not g.validate()
+
+    for i in range(17):
+        for j in range(10):
+            g.add_edge(i, (7 * i + 23 * j) % 17, 31 + j)
+
+    assert g.number_of_edges() == 41 * 17
+    assert g.number_of_nodes() == 17
+
+
+def test_002():
+    g = WordGraph()
+    g.add_to_out_degree(1)
+    add_cycle(g, 32)
+    assert g.scc_id(0) == 0
+
+    g = WordGraph()
+    g.add_to_out_degree(1)
+    add_cycle(g, 33)
+    assert list(g.sccs_iterator()) == [
+        [
+            32,
+            31,
+            30,
+            29,
+            28,
+            27,
+            26,
+            25,
+            24,
+            23,
+            22,
+            21,
+            20,
+            19,
+            18,
+            17,
+            16,
+            15,
+            14,
+            13,
+            12,
+            11,
+            10,
+            9,
+            8,
+            7,
+            6,
+            5,
+            4,
+            3,
+            2,
+            1,
+            0,
+        ]
+    ]
+    for i in range(33):
+        assert g.scc_id(i) == 0
+
+
+def test_003():
+    graph = WordGraph(0)
+    for j in range(1, 100):
+        graph.add_nodes(j)
+        for i in range(j * (j + 1) // 2):
+            assert graph.scc_id(i) == i
+
+
+def test_004():
+    graph = WordGraph(10, 5)
+    with pytest.raises(RuntimeError):
+        graph.neighbor(10, 0)
+    assert graph.neighbor(0, 1) == UNDEFINED
+
+    with pytest.raises(RuntimeError):
+        graph.add_edge(0, 10, 0)
+    with pytest.raises(RuntimeError):
+        graph.add_edge(10, 0, 0)
+    for i in range(5):
+        graph.add_edge(0, 1, i)
+        graph.add_edge(2, 2, i)
+    graph.add_edge(0, 1, 0)
+    graph.add_edge(2, 2, 0)
+
+    with pytest.raises(RuntimeError):
+        graph.scc_id(10)
+
+
+def test_005():
+    for k in range(2, 50):
+        graph = WordGraph(k, k)
+        for i in range(k):
+            for j in range(k):
+                graph.add_edge(i, j, j)
+
+    assert graph.number_of_scc() == 1
+
+    forest = graph.spanning_forest()
+    assert forest.parent(k - 1) == UNDEFINED
+    graph.reverse_spanning_forest()
+
+
+def test_006():
+    j = 33
+    graph = WordGraph()
+    graph.add_to_out_degree(1)
+    for k in range(10):
+        graph.add_nodes(j)
+        for i in range(k * j, (k + 1) * j - 1):
+            graph.add_edge(i, i + 1, 0)
+        graph.add_edge((k + 1) * j - 1, k * j, 0)
+    for i in range(10 * j):
+        assert graph.scc_id(i) == i // j
+
+    forest = graph.spanning_forest()
+
+    assert list(forest.parent_iterator()) == [
+        32,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        UNDEFINED,
+        65,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        45,
+        46,
+        47,
+        48,
+        49,
+        50,
+        51,
+        52,
+        53,
+        54,
+        55,
+        56,
+        57,
+        58,
+        59,
+        60,
+        61,
+        62,
+        63,
+        UNDEFINED,
+        98,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        85,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        UNDEFINED,
+        131,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        128,
+        129,
+        UNDEFINED,
+        164,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        144,
+        145,
+        146,
+        147,
+        148,
+        149,
+        150,
+        151,
+        152,
+        153,
+        154,
+        155,
+        156,
+        157,
+        158,
+        159,
+        160,
+        161,
+        162,
+        UNDEFINED,
+        197,
+        165,
+        166,
+        167,
+        168,
+        169,
+        170,
+        171,
+        172,
+        173,
+        174,
+        175,
+        176,
+        177,
+        178,
+        179,
+        180,
+        181,
+        182,
+        183,
+        184,
+        185,
+        186,
+        187,
+        188,
+        189,
+        190,
+        191,
+        192,
+        193,
+        194,
+        195,
+        UNDEFINED,
+        230,
+        198,
+        199,
+        200,
+        201,
+        202,
+        203,
+        204,
+        205,
+        206,
+        207,
+        208,
+        209,
+        210,
+        211,
+        212,
+        213,
+        214,
+        215,
+        216,
+        217,
+        218,
+        219,
+        220,
+        221,
+        222,
+        223,
+        224,
+        225,
+        226,
+        227,
+        228,
+        UNDEFINED,
+        263,
+        231,
+        232,
+        233,
+        234,
+        235,
+        236,
+        237,
+        238,
+        239,
+        240,
+        241,
+        242,
+        243,
+        244,
+        245,
+        246,
+        247,
+        248,
+        249,
+        250,
+        251,
+        252,
+        253,
+        254,
+        255,
+        256,
+        257,
+        258,
+        259,
+        260,
+        261,
+        UNDEFINED,
+        296,
+        264,
+        265,
+        266,
+        267,
+        268,
+        269,
+        270,
+        271,
+        272,
+        273,
+        274,
+        275,
+        276,
+        277,
+        278,
+        279,
+        280,
+        281,
+        282,
+        283,
+        284,
+        285,
+        286,
+        287,
+        288,
+        289,
+        290,
+        291,
+        292,
+        293,
+        294,
+        UNDEFINED,
+        329,
+        297,
+        298,
+        299,
+        300,
+        301,
+        302,
+        303,
+        304,
+        305,
+        306,
+        307,
+        308,
+        309,
+        310,
+        311,
+        312,
+        313,
+        314,
+        315,
+        316,
+        317,
+        318,
+        319,
+        320,
+        321,
+        322,
+        323,
+        324,
+        325,
+        326,
+        327,
+        UNDEFINED,
+    ]

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,356 @@
+def test_020():
+    "cbegin/end_panislo - 100 node path"
+    wg = WordGraph()
+    n = 100
+    wg.add_nodes(n)
+    wg.add_to_out_degree(2)
+    for i in range(n - 1):
+        wg.add_edge(i, i + 1, i % 2)
+    assert len(list(wg.panilo_iterator(0, 0, POSITIVE_INFINITY))) == 100
+    assert sum(1 for _ in wg.panilo_iterator(50, 0, POSITIVE_INFINITY)) == 50
+    pths = list(wg.panislo_iterator(0, 0, POSITIVE_INFINITY))
+    assert len(pths) == 100
+    assert pths[3][0] == [0, 1, 0]
+
+    assert sum(1 for _ in wg.panislo_iterator(50, 0, POSITIVE_INFINITY)) == 50
+
+
+def test_024():
+
+    wg = WordGraph()
+    wg.add_nodes(6)
+    wg.add_to_out_degree(2)
+
+    wg.add_edge(0, 1, 0)
+    wg.add_edge(0, 2, 1)
+    wg.add_edge(1, 3, 0)
+    wg.add_edge(1, 4, 1)
+    wg.add_edge(2, 4, 0)
+    wg.add_edge(2, 2, 1)
+    wg.add_edge(3, 1, 0)
+    wg.add_edge(3, 5, 1)
+    wg.add_edge(4, 5, 0)
+    wg.add_edge(4, 4, 1)
+    wg.add_edge(5, 4, 0)
+    wg.add_edge(5, 5, 1)
+
+    wg.validate()
+
+    N = 18
+
+    assert wg.number_of_paths(0, 4, 0, N) == 131062
+    assert wg.number_of_paths(0, 4, 10, N) == 130556
+    assert wg.number_of_paths(4, 1, 0, N) == 0
+    assert wg.number_of_paths(0, 0, POSITIVE_INFINITY) == POSITIVE_INFINITY
+    assert wg.number_of_paths(0, 0, 10) == 1023
+
+    assert not action_digraph_helper.is_acyclic(wg)
+
+    expected = sorted(
+        [
+            [0, 1],
+            [1, 0],
+            [0, 1, 1],
+            [1, 1, 0],
+            [1, 0, 1],
+            [1, 1, 0, 1],
+            [1, 0, 1, 1],
+            [1, 1, 1, 0],
+            [0, 1, 1, 1],
+            [1, 0, 0, 0],
+            [0, 0, 0, 1],
+            [0, 0, 1, 0],
+            [0, 1, 0, 0],
+        ]
+    )
+
+    assert list(wg.pstilo_iterator(0, 4, 0, 5)) == expected
+
+    expected = []
+    for w in wilo(2, N, [], [1] * N):
+        node = action_digraph_helper.follow_path(wg, 0, w)
+        if node == 4:
+            expected.append(w)
+    assert len(expected) == 131_062
+
+    result = list(wg.pstilo_iterator(0, 4, 0, N))
+    assert len(result) == 131_062
+    assert result == expected
+
+
+def test_036():
+    algorithm = WordGraph.algorithm
+
+    wg = WordGraph()
+    wg.add_nodes(10)
+    wg.add_to_out_degree(20)
+    wg.add_edge(0, 7, 5)
+    wg.add_edge(0, 5, 7)
+    wg.add_edge(1, 9, 14)
+    wg.add_edge(1, 5, 17)
+    wg.add_edge(3, 8, 5)
+    wg.add_edge(5, 8, 1)
+    wg.add_edge(6, 8, 14)
+    wg.add_edge(7, 8, 10)
+    wg.add_edge(8, 9, 12)
+    wg.add_edge(8, 9, 13)
+
+    assert is_acyclic(wg)
+    assert not wg.validate()
+
+    assert wg.number_of_paths_algorithm(0, 0, 16) == algorithm.acyclic
+    assert wg.number_of_paths(0, 0, 30) == 9
+    assert wg.number_of_paths(1, 0, 10, algorithm.matrix) == 6
+    assert wg.number_of_paths(1, 9, 0, 10, algorithm.matrix) == 3
+
+
+def test_037():  # pylint: disable=too-many-statements
+    algorithm = WordGraph.algorithm
+    n = 10
+    wg = WordGraph()
+    wg.add_nodes(10)
+    wg.add_to_out_degree(20)
+    wg.add_edge(0, 9, 0)
+    wg.add_edge(0, 1, 1)
+    wg.add_edge(0, 6, 2)
+    wg.add_edge(0, 3, 3)
+    wg.add_edge(0, 7, 4)
+    wg.add_edge(0, 2, 5)
+    wg.add_edge(0, 2, 6)
+    wg.add_edge(0, 8, 7)
+    wg.add_edge(0, 1, 8)
+    wg.add_edge(0, 4, 9)
+    wg.add_edge(0, 3, 10)
+    wg.add_edge(0, 1, 11)
+    wg.add_edge(0, 7, 12)
+    wg.add_edge(0, 9, 13)
+    wg.add_edge(0, 4, 14)
+    wg.add_edge(0, 7, 15)
+    wg.add_edge(0, 8, 16)
+    wg.add_edge(0, 9, 17)
+    wg.add_edge(0, 6, 18)
+    wg.add_edge(0, 9, 19)
+    wg.add_edge(1, 8, 0)
+    wg.add_edge(1, 2, 1)
+    wg.add_edge(1, 5, 2)
+    wg.add_edge(1, 7, 3)
+    wg.add_edge(1, 9, 4)
+    wg.add_edge(1, 0, 5)
+    wg.add_edge(1, 2, 6)
+    wg.add_edge(1, 4, 7)
+    wg.add_edge(1, 0, 8)
+    wg.add_edge(1, 3, 9)
+    wg.add_edge(1, 2, 10)
+    wg.add_edge(1, 7, 11)
+    wg.add_edge(1, 2, 12)
+    wg.add_edge(1, 7, 13)
+    wg.add_edge(1, 6, 14)
+    wg.add_edge(1, 6, 15)
+    wg.add_edge(1, 5, 16)
+    wg.add_edge(1, 4, 17)
+    wg.add_edge(1, 6, 18)
+    wg.add_edge(1, 3, 19)
+    wg.add_edge(2, 2, 0)
+    wg.add_edge(2, 9, 1)
+    wg.add_edge(2, 0, 2)
+    wg.add_edge(2, 6, 3)
+    wg.add_edge(2, 7, 4)
+    wg.add_edge(2, 9, 5)
+    wg.add_edge(2, 5, 6)
+    wg.add_edge(2, 4, 7)
+    wg.add_edge(2, 9, 8)
+    wg.add_edge(2, 7, 9)
+    wg.add_edge(2, 9, 10)
+    wg.add_edge(2, 9, 11)
+    wg.add_edge(2, 0, 12)
+    wg.add_edge(2, 7, 13)
+    wg.add_edge(2, 9, 14)
+    wg.add_edge(2, 6, 15)
+    wg.add_edge(2, 3, 16)
+    wg.add_edge(2, 3, 17)
+    wg.add_edge(2, 4, 18)
+    wg.add_edge(2, 1, 19)
+    wg.add_edge(3, 1, 0)
+    wg.add_edge(3, 9, 1)
+    wg.add_edge(3, 6, 2)
+    wg.add_edge(3, 2, 3)
+    wg.add_edge(3, 9, 4)
+    wg.add_edge(3, 8, 5)
+    wg.add_edge(3, 1, 6)
+    wg.add_edge(3, 6, 7)
+    wg.add_edge(3, 1, 8)
+    wg.add_edge(3, 0, 9)
+    wg.add_edge(3, 5, 10)
+    wg.add_edge(3, 0, 11)
+    wg.add_edge(3, 2, 12)
+    wg.add_edge(3, 7, 13)
+    wg.add_edge(3, 4, 14)
+    wg.add_edge(3, 0, 15)
+    wg.add_edge(3, 4, 16)
+    wg.add_edge(3, 8, 17)
+    wg.add_edge(3, 3, 18)
+    wg.add_edge(3, 1, 19)
+    wg.add_edge(4, 0, 0)
+    wg.add_edge(4, 4, 1)
+    wg.add_edge(4, 8, 2)
+    wg.add_edge(4, 5, 3)
+    wg.add_edge(4, 5, 4)
+    wg.add_edge(4, 1, 5)
+    wg.add_edge(4, 3, 6)
+    wg.add_edge(4, 8, 7)
+    wg.add_edge(4, 4, 8)
+    wg.add_edge(4, 4, 9)
+    wg.add_edge(4, 4, 10)
+    wg.add_edge(4, 7, 11)
+    wg.add_edge(4, 8, 12)
+    wg.add_edge(4, 6, 13)
+    wg.add_edge(4, 3, 14)
+    wg.add_edge(4, 7, 15)
+    wg.add_edge(4, 6, 16)
+    wg.add_edge(4, 7, 17)
+    wg.add_edge(4, 0, 18)
+    wg.add_edge(4, 2, 19)
+    wg.add_edge(5, 3, 0)
+    wg.add_edge(5, 0, 1)
+    wg.add_edge(5, 4, 2)
+    wg.add_edge(5, 7, 3)
+    wg.add_edge(5, 2, 4)
+    wg.add_edge(5, 5, 5)
+    wg.add_edge(5, 7, 6)
+    wg.add_edge(5, 7, 7)
+    wg.add_edge(5, 7, 8)
+    wg.add_edge(5, 7, 9)
+    wg.add_edge(5, 0, 10)
+    wg.add_edge(5, 8, 11)
+    wg.add_edge(5, 6, 12)
+    wg.add_edge(5, 8, 13)
+    wg.add_edge(5, 8, 14)
+    wg.add_edge(5, 1, 15)
+    wg.add_edge(5, 5, 16)
+    wg.add_edge(5, 5, 17)
+    wg.add_edge(5, 3, 18)
+    wg.add_edge(5, 7, 19)
+    wg.add_edge(6, 8, 0)
+    wg.add_edge(6, 7, 1)
+    wg.add_edge(6, 6, 2)
+    wg.add_edge(6, 5, 3)
+    wg.add_edge(6, 6, 4)
+    wg.add_edge(6, 1, 5)
+    wg.add_edge(6, 7, 6)
+    wg.add_edge(6, 2, 7)
+    wg.add_edge(6, 7, 8)
+    wg.add_edge(6, 3, 9)
+    wg.add_edge(6, 3, 10)
+    wg.add_edge(6, 8, 11)
+    wg.add_edge(6, 3, 12)
+    wg.add_edge(6, 9, 13)
+    wg.add_edge(6, 4, 14)
+    wg.add_edge(6, 1, 15)
+    wg.add_edge(6, 4, 16)
+    wg.add_edge(6, 3, 17)
+    wg.add_edge(6, 9, 18)
+    wg.add_edge(6, 8, 19)
+    wg.add_edge(7, 9, 0)
+    wg.add_edge(7, 4, 1)
+    wg.add_edge(7, 3, 2)
+    wg.add_edge(7, 8, 3)
+    wg.add_edge(7, 0, 4)
+    wg.add_edge(7, 5, 5)
+    wg.add_edge(7, 6, 6)
+    wg.add_edge(7, 8, 7)
+    wg.add_edge(7, 9, 8)
+    wg.add_edge(7, 1, 9)
+    wg.add_edge(7, 7, 10)
+    wg.add_edge(7, 0, 11)
+    wg.add_edge(7, 6, 12)
+    wg.add_edge(7, 2, 13)
+    wg.add_edge(7, 3, 14)
+    wg.add_edge(7, 8, 15)
+    wg.add_edge(7, 6, 16)
+    wg.add_edge(7, 3, 17)
+    wg.add_edge(7, 2, 18)
+    wg.add_edge(7, 7, 19)
+    wg.add_edge(8, 0, 0)
+    wg.add_edge(8, 6, 1)
+    wg.add_edge(8, 3, 2)
+    wg.add_edge(8, 5, 3)
+    wg.add_edge(8, 7, 4)
+    wg.add_edge(8, 9, 5)
+    wg.add_edge(8, 9, 6)
+    wg.add_edge(8, 8, 7)
+    wg.add_edge(8, 1, 8)
+    wg.add_edge(8, 5, 9)
+    wg.add_edge(8, 7, 10)
+    wg.add_edge(8, 9, 11)
+    wg.add_edge(8, 6, 12)
+    wg.add_edge(8, 0, 13)
+    wg.add_edge(8, 0, 14)
+    wg.add_edge(8, 3, 15)
+    wg.add_edge(8, 6, 16)
+    wg.add_edge(8, 0, 17)
+    wg.add_edge(8, 8, 18)
+    wg.add_edge(8, 9, 19)
+    wg.add_edge(9, 3, 0)
+    wg.add_edge(9, 7, 1)
+    wg.add_edge(9, 9, 2)
+    wg.add_edge(9, 1, 3)
+    wg.add_edge(9, 4, 4)
+    wg.add_edge(9, 9, 5)
+    wg.add_edge(9, 4, 6)
+    wg.add_edge(9, 0, 7)
+    wg.add_edge(9, 5, 8)
+    wg.add_edge(9, 8, 9)
+    wg.add_edge(9, 3, 10)
+    wg.add_edge(9, 2, 11)
+    wg.add_edge(9, 0, 12)
+    wg.add_edge(9, 2, 13)
+    wg.add_edge(9, 3, 14)
+    wg.add_edge(9, 4, 15)
+    wg.add_edge(9, 0, 16)
+    wg.add_edge(9, 5, 17)
+    wg.add_edge(9, 3, 18)
+    wg.add_edge(9, 5, 19)
+    assert not is_acyclic(wg)
+    assert wg.validate()
+
+    assert wg.number_of_paths_algorithm(0) == algorithm.acyclic
+    assert wg.number_of_paths(0) == POSITIVE_INFINITY
+    with pytest.raises(RuntimeError):
+        wg.number_of_paths(0, 0, 10, algorithm.acyclic)
+    with pytest.raises(RuntimeError):
+        wg.number_of_paths(1, 9, 0, 10, algorithm.acyclic)
+
+    wg = binary_tree(n)
+    assert wg.number_of_paths_algorithm(0) == algorithm.acyclic
+    assert wg.number_of_paths(0) == 1023
+
+    add_cycle(wg, n)
+    wg.add_edge(0, n + 1, 0)
+    assert not is_acyclic(wg)
+    assert not wg.validate()
+    assert wg.number_of_paths(1) == 511
+    assert (
+        wg.number_of_paths_algorithm(1, 0, POSITIVE_INFINITY)
+        == algorithm.acyclic
+    )
+    assert wg.number_of_paths(1, 0, POSITIVE_INFINITY) == 511
+    assert len(topological_sort(wg)) == 0
+    for m in wg.nodes_iterator():
+        if len(topological_sort(wg, m)) == 0:
+            assert m == 1023
+            break
+
+
+def test_follow_path():
+    wg = binary_tree(8)
+    assert wg.number_of_nodes() == 255
+    assert follow_path(wg, 0, [0, 1, 0, 1]) == 20
+    assert follow_path(wg, 0, []) == 0
+    for i, w in enumerate(wg.pislo_iterator(0, 0, 10)):
+        assert follow_path(wg, 0, w) == i
+    assert follow_path(wg, 1, [0] * 10) == UNDEFINED
+
+    with pytest.raises(RuntimeError):
+        follow_path(wg, 1, [2])
+    with pytest.raises(RuntimeError):
+        follow_path(wg, 312, [0, 1, 1, 0])

--- a/tests/test_wordgraph.py
+++ b/tests/test_wordgraph.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2021, J. D. Mitchell
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+
+"""
+This file contains tests for WordGraph and related functionality in
+libsemigroups_pybind11.
+"""
+
+# pylint: disable=no-name-in-module, missing-function-docstring, invalid-name,
+# pylint: disable=duplicate-code, too-many-lines
+
+import pytest
+from libsemigroups_pybind11 import (
+    POSITIVE_INFINITY,
+    UNDEFINED,
+    WordGraph,
+    word_graph,
+)
+
+
+def binary_tree(number_of_levels):
+    wg = WordGraph()
+    wg.add_nodes(2**number_of_levels - 1)
+    wg.add_to_out_degree(2)
+    wg.add_edge(0, 1, 0)
+    wg.add_edge(0, 2, 1)
+
+    for i in range(2, number_of_levels + 1):
+        counter = 2 ** (i - 1) - 1
+        for j in range(2 ** (i - 2) - 1, 2 ** (i - 1) - 1):
+            wg.add_edge(j, counter, 0)
+            counter += 1
+            wg.add_edge(j, counter, 1)
+            counter += 1
+    return wg
+
+
+def test_000():
+    g = WordGraph()
+    assert g.number_of_nodes() == 0
+    assert g.number_of_edges() == 0
+
+
+def test_001():
+    g = WordGraph(42)
+    assert g.number_of_nodes() == 42
+    assert g.number_of_edges() == 0
+
+
+def test_out_neighbors():
+    l = [[0, 1], [1, 0], [2, 2]]
+
+    d = word_graph.to_word_graph(3, l)
+    assert word_graph.out_neighbors(d) == l
+    assert d == word_graph.to_word_graph(3, word_graph.out_neighbors(d))
+
+    d = word_graph.to_word_graph(4, l)
+    ll = [[0, 1], [1, 0], [2, 2], [18446744073709551615, 18446744073709551615]]
+    assert word_graph.out_neighbors(d) == ll
+    assert word_graph.to_word_graph(4, word_graph.out_neighbors(d)) == d
+
+
+def test_dot():
+    l = [[0, 1], [1, 0], [2, 2]]
+
+    d = word_graph.to_word_graph(3, l)
+    assert (
+        str(word_graph.dot(d))
+        == 'digraph {\n\tnode [shape=box]\n\t0\n\t1\n\t2\n\t0 -> 0 [label=0 color="#cc6677"]\n\t0 -> 1 [label=1 color="#ddcc77"]\n\t1 -> 1 [label=0 color="#cc6677"]\n\t1 -> 0 [label=1 color="#ddcc77"]\n\t2 -> 2 [label=0 color="#cc6677"]\n\t2 -> 2 [label=1 color="#ddcc77"]\n}\n'  # pylint: disable=line-too-long
+    )
+
+    l = list(12 * [i] for i in range(4))
+
+    d = word_graph.to_word_graph(4, l)
+    assert (
+        str(word_graph.dot(d))
+        == 'digraph {\n\tnode [shape=box]\n\t0\n\t1\n\t2\n\t3\n\t0 -> 0 [label=0 color="#cc6677"]\n\t0 -> 0 [label=1 color="#ddcc77"]\n\t0 -> 0 [label=2 color="#117733"]\n\t0 -> 0 [label=3 color="#88ccee"]\n\t0 -> 0 [label=4 color="#44aa99"]\n\t0 -> 0 [label=5 color="#882255"]\n\t0 -> 0 [label=6 color="#44aa99"]\n\t0 -> 0 [label=7 color="#999933"]\n\t0 -> 0 [label=8 color="#332288"]\n\t0 -> 0 [label=9 color="#cc6677"]\n\t0 -> 0 [label=10 color="#ddcc77"]\n\t0 -> 0 [label=11 color="#117733"]\n\t1 -> 1 [label=0 color="#cc6677"]\n\t1 -> 1 [label=1 color="#ddcc77"]\n\t1 -> 1 [label=2 color="#117733"]\n\t1 -> 1 [label=3 color="#88ccee"]\n\t1 -> 1 [label=4 color="#44aa99"]\n\t1 -> 1 [label=5 color="#882255"]\n\t1 -> 1 [label=6 color="#44aa99"]\n\t1 -> 1 [label=7 color="#999933"]\n\t1 -> 1 [label=8 color="#332288"]\n\t1 -> 1 [label=9 color="#cc6677"]\n\t1 -> 1 [label=10 color="#ddcc77"]\n\t1 -> 1 [label=11 color="#117733"]\n\t2 -> 2 [label=0 color="#cc6677"]\n\t2 -> 2 [label=1 color="#ddcc77"]\n\t2 -> 2 [label=2 color="#117733"]\n\t2 -> 2 [label=3 color="#88ccee"]\n\t2 -> 2 [label=4 color="#44aa99"]\n\t2 -> 2 [label=5 color="#882255"]\n\t2 -> 2 [label=6 color="#44aa99"]\n\t2 -> 2 [label=7 color="#999933"]\n\t2 -> 2 [label=8 color="#332288"]\n\t2 -> 2 [label=9 color="#cc6677"]\n\t2 -> 2 [label=10 color="#ddcc77"]\n\t2 -> 2 [label=11 color="#117733"]\n\t3 -> 3 [label=0 color="#cc6677"]\n\t3 -> 3 [label=1 color="#ddcc77"]\n\t3 -> 3 [label=2 color="#117733"]\n\t3 -> 3 [label=3 color="#88ccee"]\n\t3 -> 3 [label=4 color="#44aa99"]\n\t3 -> 3 [label=5 color="#882255"]\n\t3 -> 3 [label=6 color="#44aa99"]\n\t3 -> 3 [label=7 color="#999933"]\n\t3 -> 3 [label=8 color="#332288"]\n\t3 -> 3 [label=9 color="#cc6677"]\n\t3 -> 3 [label=10 color="#ddcc77"]\n\t3 -> 3 [label=11 color="#117733"]\n}\n'  # pylint: disable=line-too-long
+    )


### PR DESCRIPTION
This is some work in progress from my branch of `libsemigroups_pybind11` which was changing the bindings to accommodate what I think we originally called the 'Todd-Coxeter refactor' changes to `libsemigroups`.

This is a PR to the **wrong base**: this is deliberate in the sense that I won't have time to do the rebase this morning, but hopefully can still avoid the duplication of work since it'll at least be visible what files I've been at here.