### PR TITLE
Add extended docstring directive

### DIFF
--- a/docs/source/reporter.rst
+++ b/docs/source/reporter.rst
@@ -9,9 +9,9 @@
 Reporter
 ========
 
-.. autoclass:: Reporter
+.. ext_autoclass:: Reporter
+   :doc-only:
    :class-doc-from: class
-   :noindex:
 
 Contents
 --------

--- a/docs/source/runner.rst
+++ b/docs/source/runner.rst
@@ -9,7 +9,9 @@
 Runner
 ======
 
-TODO
+.. ext_autoclass:: Runner
+   :doc-only:
+   :class-doc-from: class
 
 Contents
 --------
@@ -36,9 +38,9 @@ Contents
 Full API
 --------
 
-.. autoclass:: Runner
+.. ext_autoclass:: Runner
+   :no-doc:
    :members:
-   :class-doc-from: class
 
 Methods inherited from Reporter
 -------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-docutils==0.20.1
 graphviz==0.20.1
 jinja2<3.1
 nose==1.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+docutils==0.20.1
 graphviz==0.20.1
 jinja2<3.1
 nose==1.3.7


### PR DESCRIPTION
Supersedes https://github.com/james-d-mitchell/libsemigroups_pybind11/pull/3. In this PR, the new directive is used in the documentation of `Reporter` and `Runner`.  