### PR TITLE
Update the autodoc directive to improve overloaded functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ install:
 	pip3 install . --use-feature=in-tree-build
 
 black:
-	black setup.py tests/*.py libsemigroups_pybind11/*.py
+	black setup.py tests/*.py libsemigroups_pybind11/*.py docs/source/conf.py
 
 check: doctest
 	pytest -vv tests/test_*.py
 
 lint:
-	pylint --exit-zero setup.py tests/*.py libsemigroups_pybind11/*.py
+	pylint --exit-zero setup.py tests/*.py libsemigroups_pybind11/*.py docs/source/conf.py
 	cpplint src/*.hpp src/*.cpp
 
 coverage:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -244,7 +244,10 @@ autoclass_content = "both"
 # replacements will be performed globally. Hyperlinks will be added in the
 # signature if "good type" is a valid (potentially user defined) python type
 type_replacements = {
-    r"libsemigroups::Presentation<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >": r"Presentation",
+    (
+        r"libsemigroups::Presentation<std::__cxx11::basic_string<char,"
+        r"std::char_traits<char>, std::allocator<char> > >"
+    ): r"Presentation",
     r"libsemigroups::BMat8": r"BMat8",
     r"libsemigroups::WordGraph<unsigned int>": r"WordGraph",
     r"libsemigroups::Gabow<unsigned int>": r"Gabow",
@@ -257,6 +260,7 @@ class_specific_replacements = {"RowActionBMat8": (r"\bBMat8\b", "Element")}
 
 
 def sub_if_not_none(pattern, repl, *strings):
+    """Make regex replacement on inputs that are not None"""
     out = []
     for string in strings:
         if string is None:
@@ -267,6 +271,7 @@ def sub_if_not_none(pattern, repl, *strings):
 
 
 def change_sig(app, what, name, obj, options, signature, return_annotation):
+    """Make type replacement in function signatures"""
     # if what in to_replace:
     for typename, repl in type_replacements.items():
         signature, return_annotation = sub_if_not_none(

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,14 @@ class ExtendedAutodocDirective(AutodocDirective):
         return output
 
     def basic_run(self):
-        """Generate and parse the docstring"""
+        """Generate and parse the docstring
+
+        This is almost identical to AutodocDirective.run(), with the added step
+        that allows for better overloaded functions.
+
+        See:
+        https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/autodoc/directive.py
+        """
         reporter = self.state.document.reporter
 
         try:

--- a/docs/source/data-structures/misc/reporter.rst
+++ b/docs/source/data-structures/misc/reporter.rst
@@ -9,7 +9,7 @@
 Reporter
 ========
 
-.. ext_autoclass:: Reporter
+.. autoclass:: Reporter
    :doc-only:
    :class-doc-from: class
 

--- a/docs/source/data-structures/misc/runner.rst
+++ b/docs/source/data-structures/misc/runner.rst
@@ -9,7 +9,7 @@
 Runner
 ======
 
-.. ext_autoclass:: Runner
+.. autoclass:: Runner
    :doc-only:
    :class-doc-from: class
 
@@ -38,7 +38,7 @@ Contents
 Full API
 --------
 
-.. ext_autoclass:: Runner
+.. autoclass:: Runner
    :no-doc:
    :members:
 


### PR DESCRIPTION
This PR improves how overloaded functions get rendered in the documentation. Specifically, it formats them in the same that non-overloaded functions get formatted, and adds a level of indentation.

I decided to use this directive to override the standard `autoclass` and `autofunction` directives, since it provides a superset of their functionality. The only downside that I can see is that this causes a `directive already registered` warning. If this is undesirable I can call it something else.  