### PR TITLE
Add only-document-once option

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -221,9 +221,6 @@ def fix_overloads(app, what, name, obj, options, lines):
     """Indent overloaded function documentation and format signatures"""
 
     for line in lines:
-        if "redundant_rule" in line:
-            print("\n")
-            print(line)
         m = re.search(r"\s*?\d+\. (.*?)\(", line)
         if m is not None:
             func_name = m.group(1)

--- a/docs/source/main-algorithms/knuth-bendix/kb-helpers.rst
+++ b/docs/source/main-algorithms/knuth-bendix/kb-helpers.rst
@@ -19,6 +19,9 @@ submodule ``libsemigroups_pybind11.knuth_bendix``.
 
 Contents
 --------
+
+.. currentmodule:: libsemigroups_pybind11.knuth_bendix
+
 .. autosummary::
    :nosignatures:
 
@@ -26,6 +29,7 @@ Contents
    is_reduced
    non_trivial_classes
    normal_forms
+   redundant_rule
 
 Full API
 --------

--- a/etc/replace-strings-in-doc.py
+++ b/etc/replace-strings-in-doc.py
@@ -44,6 +44,7 @@ replacements = {
     "RowActionBMat8": "Action",
     "libsemigroups::BMat8": "BMat8",
     "libsemigroups_pybind11.bmat8": "bmat8",
+    "libsemigroups_pybind11.knuth_bendix": "knuth_bendix",
 }
 files = all_html_files(html_path)
 

--- a/src/knuth-bendix.cpp
+++ b/src/knuth-bendix.cpp
@@ -465,6 +465,7 @@ The handedness of the congruence (left, right, or 2-sided).
             knuth_bendix::by_overlap_length(kb);
           },
           R"pbdoc(
+:sig=(kb: KnuthBendixRewriteTrie):
 :only-document-once:
 TODO
         )pbdoc");
@@ -474,6 +475,7 @@ TODO
             return knuth_bendix::normal_forms(kb);
           },
           R"pbdoc(
+:sig=(kb: KnuthBendixRewriteTrie):
 :only-document-once:
 TODO
         )pbdoc");
@@ -483,6 +485,7 @@ TODO
             return knuth_bendix::non_trivial_classes(kb1, kb2);
           },
           R"pbdoc(
+:sig=(kb1: KnuthBendixRewriteTrie, kb2: KnuthBendixRewriteTrie):
 :only-document-once:
 TODO
         )pbdoc");
@@ -492,6 +495,7 @@ TODO
             return knuth_bendix::is_reduced(kb1);
           },
           R"pbdoc(
+:sig=(kb: KnuthBendixRewriteTrie):
 :only-document-once:
 TODO
         )pbdoc");
@@ -503,6 +507,7 @@ TODO
                                  knuth_bendix::redundant_rule(p, t));
           },
           R"pbdoc(
+:sig=(p: Presentation, t: datetime.timedelta):
 :only-document-once:
 Return the index of the the left hand side of a redundant rule.
 
@@ -550,6 +555,7 @@ is returned.
           "is_obviously_infinite",
           [](KnuthBendix<Rewriter>& kb) { return is_obviously_infinite(kb); },
           R"pbdoc(
+:sig=(kb: KnuthBendixRewriteTrie):
 :only-document-once:
 TODO
         )pbdoc");

--- a/src/knuth-bendix.cpp
+++ b/src/knuth-bendix.cpp
@@ -459,22 +459,42 @@ The handedness of the congruence (left, right, or 2-sided).
       //////////////////////////////////////////////////////////////////////////
       // Helpers
       //////////////////////////////////////////////////////////////////////////
-      m.def("by_overlap_length", [](KnuthBendix<Rewriter>& kb) {
-        knuth_bendix::by_overlap_length(kb);
-      });
+      m.def(
+          "by_overlap_length",
+          [](KnuthBendix<Rewriter>& kb) {
+            knuth_bendix::by_overlap_length(kb);
+          },
+          R"pbdoc(
+:only-document-once:
+TODO
+        )pbdoc");
       m.def(
           "normal_forms",
           [](KnuthBendix<Rewriter>& kb) {
             return knuth_bendix::normal_forms(kb);
           },
-          R"pbdoc(Test)pbdoc");
-      m.def("non_trivial_classes",
-            [](KnuthBendix<Rewriter>& kb1, KnuthBendix<Rewriter>& kb2) {
-              return knuth_bendix::non_trivial_classes(kb1, kb2);
-            });
-      m.def("is_reduced", [](KnuthBendix<Rewriter>& kb1) {
-        return knuth_bendix::is_reduced(kb1);
-      });
+          R"pbdoc(
+:only-document-once:
+TODO
+        )pbdoc");
+      m.def(
+          "non_trivial_classes",
+          [](KnuthBendix<Rewriter>& kb1, KnuthBendix<Rewriter>& kb2) {
+            return knuth_bendix::non_trivial_classes(kb1, kb2);
+          },
+          R"pbdoc(
+:only-document-once:
+TODO
+        )pbdoc");
+      m.def(
+          "is_reduced",
+          [](KnuthBendix<Rewriter>& kb1) {
+            return knuth_bendix::is_reduced(kb1);
+          },
+          R"pbdoc(
+:only-document-once:
+TODO
+        )pbdoc");
       // REVIEW should the the report guard be turned off for this?
       m.def(
           "redundant_rule",
@@ -483,6 +503,7 @@ The handedness of the congruence (left, right, or 2-sided).
                                  knuth_bendix::redundant_rule(p, t));
           },
           R"pbdoc(
+:only-document-once:
 Return the index of the the left hand side of a redundant rule.
 
 Starting with the last rule in the presentation, this function attempts to
@@ -525,9 +546,13 @@ is returned.
   >>> knuth_bendix.redundant_rule(p, t)
   2
             )pbdoc");
-      m.def("is_obviously_infinite", [](KnuthBendix<Rewriter>& kb) {
-        return is_obviously_infinite(kb);
-      });
+      m.def(
+          "is_obviously_infinite",
+          [](KnuthBendix<Rewriter>& kb) { return is_obviously_infinite(kb); },
+          R"pbdoc(
+:only-document-once:
+TODO
+        )pbdoc");
     }
   }  // namespace
 


### PR DESCRIPTION
This PR introduces the option `:only-document-once:`. Any docstring that starts with this option will only appear once in that functions entry in the documentation, even if that function is overloaded. This is useful when overloaded functions get created as a consequence of types hidden from the user.

In order to specify what the signature of the overloaded function should be (instead of the default `(*args, **kwargs)`), you can specify `:sig=<NEW_SIGNATURE>:` before the `:only-document-once:` option.