### PR TITLE
Create an environment for developing

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,15 +15,14 @@ external version of ``fmt`` that can be found using the environment variable
 bindings can be ``pip`` installed. This may require the environment variable
 ``$PKG_CONFIG_PATH`` to be edited.
 
-To create a conda environment with ``fmt``, ``pip``, and correct environment
-variables :
+To create an environment with ``fmt``, ``pip``, and correct environment variables:
 
 .. code-block:: bash
     
-    conda create -n libsemigroups python pip fmt
-    conda activate libsemigroups
-    conda env config vars set LD_LIBRARY_PATH="$CONDA_PREFIX/lib"
-    conda env config vars set PKG_CONFIG_PATH="$CONDA_PREFIX/lib/pkgconfig:$CONDA_PREFIX/share/pkgconfig:/usr/local/lib/pkgconfig"
+    source etc/make-dev-environment.sh [package_manager]
+
+where [package_manager] is your favourite conda-like package manager, such as
+conda, mamba or micromamba. The default value is mamba.
 
 To build libsemigroups (with the above environment active):
 
@@ -31,7 +30,8 @@ To build libsemigroups (with the above environment active):
 
     git clone https://github.com/libsemigroups/libsemigroups
     cd libsemigroups
-    ./autogen.sh && ./configure --disable-hpcombi --with-external-fmt && sudo make install -j8
+    ./autogen.sh && ./configure --disable-hpcombi --with-external-fmt && make -j8
+    sudo make install
 
 where ``-j8`` instructs the compiler to use 8 threads.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,8 @@ To create an environment with ``fmt``, ``pip``, and correct environment variable
     source etc/make-dev-environment.sh [package_manager]
 
 where [package_manager] is your favourite conda-like package manager, such as
-conda, mamba or micromamba. The default value is mamba.
+conda, mamba. The default value is mamba. Note that this DOES NOT *yet* work
+with micromamba.
 
 To build libsemigroups (with the above environment active):
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -1,8 +1,8 @@
-# name: libsemigroups_pybind11_dev
+name: libsemigroups_pybind11_dev
 
-name: test
 channels:
   - conda-forge
+  - nodefaults
 
 dependencies:
   - python=3.12
@@ -22,7 +22,3 @@ dependencies:
   - sphinxcontrib-bibtex
   - pip:
       - accepts
-
-variables:
-  LD_LIBRARY_PATH: ${CONDA_PREFIX}/lib:/usr/local/lib
-  PKG_CONFIG_PATH: ${CONDA_PREFIX}/lib/pkgconfig:${CONDA_PREFIX}/share/pkgconfig:/usr/local/lib/pkgconfig

--- a/etc/make-dev-environment.sh
+++ b/etc/make-dev-environment.sh
@@ -1,12 +1,27 @@
 #!/bin/bash
+is_sourced() {
+    if [ -n "$ZSH_VERSION" ]; then
+        case $ZSH_EVAL_CONTEXT in *:file:*) return 0 ;; esac
+    else
+        case ${0##*/} in dash | -dash | bash | -bash | ksh | -ksh | sh | -sh) return 0 ;; esac
+    fi
+    return 1 # NOT sourced.
+}
+
+is_sourced && sourced=1 || sourced=0
+if [[ $sourced -ne 1 ]]; then
+    echo This script must be sourced, rather than run directly. Please try again with:
+    echo source $(basename "$0")
+    exit
+fi
+
+unset sourced
 
 if [[ $# -eq 0 ]]; then
     dev_env_pkg_manager=mamba
 else
     dev_env_pkg_manager=$1
 fi
-
-echo $dev_env_pkg_manager
 
 if { $dev_env_pkg_manager env list | grep 'libsemigroups_pybind11_dev'; } >/dev/null 2>&1; then
     echo The environment libsemigroups_pybind11_dev already exists. Stopping ...

--- a/etc/make-dev-environment.sh
+++ b/etc/make-dev-environment.sh
@@ -28,7 +28,7 @@ if { $dev_env_pkg_manager env list | grep 'libsemigroups_pybind11_dev'; } >/dev/
     unset dev_env_pkg_manager
     return
 else
-    echo Making libsemigroups_pybind11_dev envinronment using $dev_env_pkg_manager ...
+    echo Making libsemigroups_pybind11_dev environment using $dev_env_pkg_manager ...
     echo
     $dev_env_pkg_manager env create -f dev-environment.yml
     if [[ $? -ne 0 ]]; then
@@ -44,7 +44,7 @@ else
     fi
 fi
 
-echo Setting envinronment variables ...
+echo Setting environment variables ...
 echo
 ./etc/set-conda-environment-variables.sh -m $dev_env_pkg_manager
 

--- a/etc/make-dev-environment.sh
+++ b/etc/make-dev-environment.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+if [[ $# -eq 0 ]]; then
+    dev_env_pkg_manager=mamba
+else
+    dev_env_pkg_manager=$1
+fi
+
+echo $dev_env_pkg_manager
+
+if { $dev_env_pkg_manager env list | grep 'libsemigroups_pybind11_dev'; } >/dev/null 2>&1; then
+    echo The environment libsemigroups_pybind11_dev already exists. Stopping ...
+    unset dev_env_pkg_manager
+    return
+else
+    echo Making libsemigroups_pybind11_dev envinronment using $dev_env_pkg_manager ...
+    echo
+    $dev_env_pkg_manager env create -f dev-environment.yml
+    if [[ $? -ne 0 ]]; then
+        unset dev_env_pkg_manager
+        return
+    fi
+    echo Activating libsemigroups_pybind11_dev ...
+    echo
+    $dev_env_pkg_manager activate libsemigroups_pybind11_dev
+    if [[ $? -ne 0 ]]; then
+        unset dev_env_pkg_manager
+        return
+    fi
+fi
+
+echo Setting envinronment variables ...
+echo
+./etc/set-conda-environment-variables.sh -m $dev_env_pkg_manager
+
+echo
+echo Reactivating environment ...
+echo
+
+$dev_env_pkg_manager deactivate
+if [[ $? -ne 0 ]]; then
+    unset dev_env_pkg_manager
+    return
+fi
+$dev_env_pkg_manager activate libsemigroups_pybind11_dev
+if [[ $? -ne 0 ]]; then
+    unset dev_env_pkg_manager
+    return
+fi
+
+echo
+echo Checking environment variables ...
+echo
+echo LD_LIBRARY_PATH: $LD_LIBRARY_PATH
+echo PKG_CONFIG_PATH: $PKG_CONFIG_PATH
+
+unset dev_env_pkg_manager

--- a/etc/set-conda-environment-variables.sh
+++ b/etc/set-conda-environment-variables.sh
@@ -22,9 +22,8 @@ fi
 
 if [[ "$force" != true ]] && [[ $CONDA_DEFAULT_ENV != "libsemigroups_pybind11_dev" ]]; then
     echo The current $dev_env_pkg_manager environment is \"$CONDA_DEFAULT_ENV\", but this script is intended to be run in
-    echo \"libsemigroups_pybind11_dev\". If you wish to run this script anyway, please use the option -f.
-    echo
-    echo ./set-conda-environment -f
+    echo \"libsemigroups_pybind11_dev\". If you wish to run this script anyway, please use the option -f:
+    echo ./$(basename "$0") -f
     exit
 fi
 

--- a/etc/set-conda-environment-variables.sh
+++ b/etc/set-conda-environment-variables.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+while getopts ":fm:" option; do
+    case $option in
+    f)
+        force=true
+        ;;
+    m)
+        dev_env_pkg_manager=$OPTARG
+        ;;
+    \?) # Invalid option
+        echo "Error: Invalid option"
+        exit
+        ;;
+    esac
+done
+
+if [[ -z "${dev_env_pkg_manager}" ]]; then
+    dev_env_pkg_manager=mamba
+fi
+
+if [[ "$force" != true ]] && [[ $CONDA_DEFAULT_ENV != "libsemigroups_pybind11_dev" ]]; then
+    echo The current $dev_env_pkg_manager environment is \"$CONDA_DEFAULT_ENV\", but this script is intended to be run in
+    echo \"libsemigroups_pybind11_dev\". If you wish to run this script anyway, please use the option -f.
+    echo
+    echo ./set-conda-environment -f
+    exit
+fi
+
+echo Setting LD_LIBRARY_PATH to: $CONDA_PREFIX/lib:/usr/local/lib
+echo Setting PKG_CONFIG_PATH to: $CONDA_PREFIX/lib/pkgconfig:$CONDA_PREFIX/share/pkgconfig:/usr/local/lib/pkgconfig
+
+$dev_env_pkg_manager env config vars set -n $CONDA_DEFAULT_ENV LD_LIBRARY_PATH=$CONDA_PREFIX/lib:/usr/local/lib PKG_CONFIG_PATH=$CONDA_PREFIX/lib/pkgconfig:$CONDA_PREFIX/share/pkgconfig:/usr/local/lib/pkgconfig


### PR DESCRIPTION
This PR adds a script that can be sourced to create and activate an environment with the packages and environment variables necessary to develop `libsemigroups_pybind11`.

I had originally hoped that this would be possible using conda, mamba or micromamba. Unfortunately, micromamba doesn't presently support the feature to add environment variables for specific envs, so only conda and mamba are supported.

The contributing guide has also been updated to reflect how a developer should go about setting up their working environment.