### PR TITLE
Add doc for constants

### DIFF
--- a/docs/source/data-structures/constants/index.rst
+++ b/docs/source/data-structures/constants/index.rst
@@ -1,0 +1,41 @@
+.. Copyright (c) 2024 Joseph Edwards
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+.. currentmodule:: libsemigroups_pybind11
+
+Constants
+=========
+
+This page describes some of the constants used in ``libsemigroups_pybind11``.
+
+.. autodata:: UNDEFINED
+
+    This variable is used to indicate that a value is undefined. :any:`UNDEFINED`
+    is comparable with any integral value (signed or unsigned) or constant via
+    ``==`` and ``!=`` but not via ``<`` or ``>``.
+
+.. autodata:: POSITIVE_INFINITY
+
+    This variable represents :math:`\infty`. :any:`POSITIVE_INFINITY` is
+    comparable via ``==``, ``!=``, ``<``, ``>`` with any integral value (signed or
+    unsigned) and with  :any:`NEGATIVE_INFINITY`, and is comparable to any other
+    constant via ``==`` and ``!=``, but not by ``<`` and ``>``.
+
+.. autodata:: LIMIT_MAX
+
+    This variable represents the maximum value that certain function
+    parameters can have. :any:`LIMIT_MAX` is comparable via ``==``, ``!=``, ``<``, ``>``
+    with any integral value (signed or unsigned), and is comparable to any
+    other constant via ``==`` and ``!=``, but not by ``<`` and ``>``.
+
+.. autodata:: NEGATIVE_INFINITY
+
+    This variable represents :math:`-\infty`. :any:`NEGATIVE_INFINITY` is
+    comparable via ``==``, ``!=``, ``<``, ``>`` with any signed integral value and
+    with :any:`POSITIVE_INFINITY`, and is comparable to any other constant via
+    ``==`` and ``!=``.
+
+  

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,6 +50,7 @@ See the installation instructions:
    :caption: Data Structures
    :hidden:
 
+   data-structures/constants/index
    data-structures/elements/index
    data-structures/presentations/index
    data-structures/word-graph/index


### PR DESCRIPTION
To reduce the number of warnings produced by `make doc`, this PR adds documentation for some constants.

It wasn't entirely clear where this should be placed in the docs. Data Structures seemed to make the most sense, but I'm happy to move it if there is a better suggestion. 