### PR TITLE
Remove no-excepts

### DIFF
--- a/src/aho-corasick.cpp
+++ b/src/aho-corasick.cpp
@@ -137,8 +137,6 @@ Reinitialise an existing AhoCorasick object.
 This function puts an :any:`AhoCorasick` object back into the same state as
 if it had been newly default constructed.
 
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
-
 :complexity: Linear in the number of nodes in the trie
 
 :returns: ``self``.
@@ -152,7 +150,6 @@ Returns the number of nodes in the trie.
 
 This function Returns the number of nodes in the trie.
 
-:exceptions: This function is guaranteed never to throw.
 
 :complexity: Constant
 
@@ -177,8 +174,6 @@ of the unique path from the root to
 
 :returns: The signature
 :rtype: List[int]
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 
 :complexity: Linear in the height of the node
 )pbdoc");
@@ -298,8 +293,6 @@ this function does nothing.
     This node will have a :any:`signature` equal to that of *w*.
 :rtype: int
 
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
-
 :complexity: Linear in the length of *w*.
 
 .. seealso:: :any:`AhoCorasick.signature`
@@ -346,8 +339,6 @@ nothing.
 :returns: The index corresponding to the node with signature equal to *w*.
 :rtype: int
 
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
-
 :complexity: Linear in the length of *w*.
 
 .. seealso:: :any:`AhoCorasick.signature`
@@ -386,8 +377,6 @@ index *start*, and traversing using the letters in the word *w*.
 
 :returns: The result of the traversal
 :rtype: int
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 
 )pbdoc");
     m.def(

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -996,6 +996,7 @@ Reverse every rule.
 
 :param p: the presentation.
 :type p: PresentationStrings
+)pbdoc");
       m.def(
           "shortest_rule",
           [](Presentation_ const& p) {
@@ -1153,6 +1154,7 @@ are created by taking quotients of free semigroups or monoids.
 
 :param var_name:  the name of the variable to be used in GAP.
 :type var_name: str
+)pbdoc");
       m.def(
           "to_gap_string",
           [](Presentation<word_type> const& p, std::string const& var_name) {

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -108,8 +108,6 @@ Return the alphabet of the presentation.
 :returns: The alphabet of the presentation.
 :rtype: :ref:`Word<pseudo_word_type_class>`
 
-:exceptions: This function is guaranteed never to throw.
-
 :complexity: Constant.
 
 )pbdoc");
@@ -173,8 +171,6 @@ Set the alphabet to be the letters in the rules.
 :returns: ``self``
 :rtype: PresentationStrings
 
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
-
 :complexity: At most :math:`O(mn)` where :math:`m` is the number of rules,
   and :math:`n` is the length of the longest rule.
 
@@ -198,8 +194,6 @@ but is not given as a quotient of a free monoid.
 
 :returns: whether the presentation can contain the empty word.
 :rtype: bool
-
-:exceptions: This function is guaranteed never to throw.
 
 :complexity: Constant.
 
@@ -226,8 +220,6 @@ monoid, but is not given as a quotient of a free monoid.
 :returns: ``self``
 :rtype: PresentationStrings
 
-:exceptions: This function is guaranteed never to throw.
-
 :complexity: Constant
 )pbdoc");
       thing.def("in_alphabet",
@@ -242,8 +234,6 @@ Check if a letter belongs to the alphabet or not.
 
 :returns:  whether the letter belongs to the alphabet
 :rtype: bool
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 
 :complexity: Constant on average, worst case linear in the size of the
   alphabet.
@@ -350,8 +340,6 @@ Check if every rule consists of letters belonging to the alphabet.
 Add a generator.
 
 Add the first letter not in the alphabet as a generator, and return this letter.
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 
 :returns:  the letter added to the alphabet.
 :rtype: :ref:`Letter<pseudo_letter_type_class>`
@@ -595,8 +583,6 @@ contained in *p*.
 :returns: whether the presentation contains the rule
 :rtype: bool
 
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
-
 :complexity: Linear in the number of rules.
 )pbdoc");
       m.def("first_unused_letter",
@@ -683,8 +669,6 @@ See`Section 3.2 <https://doi.org/10.1007/s00233-021-10216-8>`_ for details.
 :returns: whether the presentation is strongly compressible
 :rtype: bool
 
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
-
 .. seealso::
       * :any:`strongly_compress`
 
@@ -703,8 +687,6 @@ Return the sum of the lengths of the rules.
 
 :returns: the length of the presentation
 :rtype: int
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 
 )pbdoc");
       m.def(
@@ -777,8 +759,6 @@ If no such word can be found, then a word of length :math:`0` is returned.
 
 :returns: the longest common subword, if it exists.
 :rtype: :ref:`Word<pseudo_word_type_helper>`.
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 
 )pbdoc");
       m.def("make_semigroup",
@@ -979,8 +959,6 @@ instance of *existing* in every rule of the form *existing* :math:`= w` or :math
 :param replacement: the replacement word.
 :type replacement: :ref:`Word<pseudo_word_type_helper>`
 
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
-
 )pbdoc");
       m.def(
           "replace_word_with_new_generator",
@@ -1018,8 +996,6 @@ Reverse every rule.
 
 :param p: the presentation.
 :type p: PresentationStrings
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.)pbdoc");
       m.def(
           "shortest_rule",
           [](Presentation_ const& p) {
@@ -1152,8 +1128,6 @@ modified version.
 :returns: whether the presentation has been modified
 :rtype: bool
 
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
-
 .. seealso::
       * :any:`is_strongly_compressible`
 
@@ -1179,8 +1153,6 @@ are created by taking quotients of free semigroups or monoids.
 
 :param var_name:  the name of the variable to be used in GAP.
 :type var_name: str
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.)pbdoc");
       m.def(
           "to_gap_string",
           [](Presentation<word_type> const& p, std::string const& var_name) {
@@ -1287,8 +1259,6 @@ Returns the inverse of each letter in the alphabet.
 
 :returns: the inverses.
 :rtype: :ref:`Word<pseudo_word_type_inv_class>`
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
       thing.def(
           "inverses",

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -414,9 +414,6 @@ running, then ``True`` is returned if and only if the last time ``self``
 was running it was stopped by a call to the nullary predicate passed to
 :any:`run_until()`.
 
-:exceptions:
-   This function guarantees not to throw a ``LibsemigroupsError``.
-
 :complexity:
    Constant.
 

--- a/src/to_presentation.cpp
+++ b/src/to_presentation.cpp
@@ -116,8 +116,6 @@ to calling this function.
 
 :returns: The presentation with the same rules as *fp*.
 :rtype: PresentationStrings
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 )pbdoc");
     m.def(
         "to_presentation",

--- a/src/transf.cpp
+++ b/src/transf.cpp
@@ -91,10 +91,6 @@ container.
                 R"pbdoc(
 Returns a hash value.
 
-:exceptions:
-   This function guarantees not to throw a
-   :any:`libsemigroups::LibsemigroupsException`.
-
 :complexity:
    Linear in :any:`degree()`.
 
@@ -533,7 +529,7 @@ of :math:`\{0, 1, \ldots, n - 1\}` for some integer :math:`n` called the
                 [name](Perm_ const& f) { return transf_repr(name, f); });
       m.def("inverse", py::overload_cast<Perm_ const&>(&inverse<N, Scalar>));
     }  // bind_perm
-  }  // namespace
+  }    // namespace
 
   void init_transf(py::module& m) {
     // Base classes

--- a/src/words.cpp
+++ b/src/words.cpp
@@ -219,8 +219,6 @@ Returns ``True`` if a :any:`WordRange` object is exhausted, and ``False`` if not
 
 :returns: Whether the range object is exhausted.
 :rtype: bool
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing1.def("count",
                &WordRange::count,
@@ -234,8 +232,6 @@ in order to find the return value of this function.
 
 :returns: The size of the range.
 :rtype: int
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing1.def(
         "first",
@@ -247,8 +243,6 @@ Returns the first word in a :any:`WordRange` object.
 
 :returns: The first word in the range.
 :rtype: List[int]
-
-:exceptions: This function is guaranteed never to throw.
 
 .. seealso:: 
     :any:`WordRange.min`
@@ -285,8 +279,6 @@ Returns the current word in a :any:`WordRange` object.
 
 :returns: The current word.
 :rtype: List[int]
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing1.def(
         "init",
@@ -299,8 +291,6 @@ had been newly default constructed, and returns that object.
 
 :returns: A reference to ``self``.
 :rtype: WordRange
-
-:exceptions: This function is guaranteed not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing1.def(
         "last",
@@ -310,8 +300,6 @@ Returns the one past the last word in a :any:`WordRange` object.
 
 :returns: One past the last word.
 :rtype: List[int]
-
-:exceptions: This function is guaranteed never to throw.
 
 .. seealso::
     :any:`WordRange.max`
@@ -353,8 +341,6 @@ Sets one past the last word in a :any:`WordRange` object to be
 
 :returns: A reference to ``self``.
 :rtype: WordRange
-
-:exceptions: This function is guaranteed not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing1.def(
         "min",
@@ -371,8 +357,6 @@ Sets the first word in a :any:`WordRange` object to be ``pow(0_w, val)``
 
 :returns: A reference to ``self``.
 :rtype: WordRange
-
-:exceptions: This function is guaranteed not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing1.def("next",
                &WordRange::next,
@@ -380,8 +364,6 @@ Sets the first word in a :any:`WordRange` object to be ``pow(0_w, val)``
 Advance to the next value.
 
 Advances a :any:`WordRange` object to the next value (if any).
-
-:exceptions: This function is guaranteed never to throw.
 
 .. seealso::  :any:`WordRange.at_end`
 )pbdoc");
@@ -395,8 +377,6 @@ Returns the current number of letters in a :any:`WordRange` object.
 
 :returns: The current number of letters.
 :rtype: int
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing1.def(
         "alphabet_size",
@@ -414,8 +394,6 @@ Sets the number of letters in a :any:`WordRange` object to *n*.
 
 :returns: A reference to ``self``.
 :rtype: WordRange
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     // TODO(now) make this link to order when it exists.
     thing1.def(
@@ -428,8 +406,6 @@ Returns the current order of the words in a :any:`WordRange` object.
 
 :returns: The current order.
 :rtype: order
-
-:exceptions: This function is guaranteed not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing1.def(
         "order",
@@ -461,8 +437,6 @@ then the return value of this function is meaningless.
 
 :returns: A value of type ``int``.
 :rtype: int
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing1.def(
         "upper_bound",
@@ -475,8 +449,6 @@ object. This setting is only used if :any:`WordRange.order()` is :any:`Order.lex
 
 :returns: A value of type :any:`int`.
 :rtype: int
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing1.def(
         "upper_bound",
@@ -495,8 +467,6 @@ This setting is only used if :any:`WordRange.order()` is :any:`Order.lex`.
 
 :returns: A reference to ``self``.
 :rtype: WordRange
-
-:exceptions: This function is guaranteed not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing1.def("valid",
                &WordRange::valid,
@@ -633,8 +603,6 @@ Returns the current alphabet in a :any:`StringRange` object.
 
 :returns: The current alphabet.
 :rtype: str
-
-:exceptions: This function is guaranteed never to throw.    
 )pbdoc");
     thing2.def(
         "alphabet",
@@ -664,8 +632,6 @@ Returns ``True`` if a :any:`StringRange` object is exhausted, and ``False`` if n
 
 :returns: Whether the object is exhausted.
 :rtype: bool
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing2.def(
         "__iter__",
@@ -679,8 +645,6 @@ Returns an iterator over the range.
 This function returns an iterator pointing to the first string in a :any:`StringRange` object.
 
 :returns: An input iterator.
-
-:exceptions: This function is guaranteed never to throw.
 
 .. seealso::
     :any:`end`.
@@ -698,8 +662,6 @@ to be looped over in order to find the return value of this function.
 
 :returns: The size of the range.
 :rtype: int
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing2.def(
         "first",
@@ -711,8 +673,6 @@ Returns the first string in a :any:`StringRange` object.
 
 :returns: The first string.
 :rtype: str
-
-:exceptions: This function is guaranteed never to throw.
 
 .. seealso::
     :any:`min`
@@ -746,8 +706,6 @@ Returns the current string in a :any:`StringRange` object.
 
 :returns: The current value.
 :rtype: str.
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing2.def(
         "init",
@@ -760,8 +718,6 @@ had been newly default constructed.
 
 :returns: A reference to ``self``.
 :rtype: StringRange
-
-:exceptions: This function is guaranteed not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing2.def(
         "last",
@@ -773,8 +729,6 @@ Returns one past the last string in a :any:`StringRange` object.
 
 :returns: One past the last string.
 :rtype: str
-
-:exceptions: This function is guaranteed never to throw.
 
 .. seealso::
     :any:`max`
@@ -820,8 +774,6 @@ corresponds to *val*.
 
 :returns: A reference to ``self``.
 :rtype: StringRange
-
-:exceptions: This function is guaranteed not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing2.def(
         "min",
@@ -842,8 +794,6 @@ corresponds to *val*.
 
 :returns: A reference to ``self``.
 :rtype: StringRange
-
-:exceptions: This function is guaranteed not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing2.def("next",
                &StringRange::next,
@@ -851,8 +801,6 @@ corresponds to *val*.
 Advance to the next value.
 
 Advances a :any:`StringRange` object to the next value (if any).
-
-:exceptions: This function is guaranteed never to throw.
 
 .. seealso::
     :any:`at_end`
@@ -867,8 +815,6 @@ Returns the current order of the strings in a :any:`StringRange` object.
 
 :returns: The current order.
 :rtype: order
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing2.def(
         "order",
@@ -900,8 +846,6 @@ Returns the number of words in a :any:`StringRange` object if
 
 :returns: A value of type ``int``.
 :rtype: int
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing2.def(
         "upper_bound",
@@ -915,8 +859,6 @@ Returns the current upper bound on the length of a string in a
 
 :returns: A value of type :any:`int`.
 :rtype: int
-
-:exceptions: This function is guaranteed never to throw.
 )pbdoc");
     thing2.def(
         "upper_bound",
@@ -935,8 +877,6 @@ This setting is only used if :any:`StringRange.order()` is :any:`Order.lex`.
 
 :returns: A reference to ``self``.
 :rtype: StringRange
-
-:exceptions: This function is guaranteed not to throw a ``LibsemigroupsError``.
 )pbdoc");
 
     ////////////////////////////////////////////////////////////////////////////
@@ -997,8 +937,6 @@ This function returns ``True`` if no alphabet has been defined, and ``False`` ot
 
 :returns: Whether the alphabet is empty.
 :rtype: bool
-
-:exceptions: This function guarantees never to throw.
 )pbdoc");
     thing3.def("alphabet",
                &ToWord::alphabet,
@@ -1016,8 +954,6 @@ performed using :any:`words.human_readable_index`.
 
 :returns: The alphabet.
 :rtype: str
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing3.def("can_convert_letter",
                &ToWord::can_convert_letter,
@@ -1047,8 +983,6 @@ been newly default constructed.
 
 :returns: A reference to ``self``.
 :rtype: ToWord
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 
 .. seealso::
     :any:`ToWord()`
@@ -1162,8 +1096,6 @@ performed using :any:`words.human_readable_letter`.
 
 :returns: The alphabet.
 :rtype: str
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing4.def("can_convert_letter",
                &ToString::can_convert_letter,
@@ -1179,8 +1111,6 @@ ToString instance, and ``False`` otherwise.
 
 :returns: Whether the letter can be converted.
 :rtype: bool
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 )pbdoc");
     thing4.def("empty",
                &ToString::empty,
@@ -1191,8 +1121,6 @@ This function return ``True`` if no alphabet has been defined, and ``False`` oth
 
 :returns: A whether the alphabet is empty.
 :rtype: bool
-
-:exceptions: This function guarantees never to throw.
 )pbdoc");
     thing4.def(
         "init",
@@ -1205,8 +1133,6 @@ had been newly default constructed.
 
 :returns: A reference to ``self``.
 :rtype: ToString
-
-:exceptions: This function guarantees never to throw.
 
 .. seealso::
     :any:`ToString()`
@@ -1323,8 +1249,6 @@ Returns a random string with the specified length over the specified alphabet.
 
 :returns: A random string.
 :rtype: str.
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 
 
 .. seealso::
@@ -1502,8 +1426,6 @@ Returns the word *x* to the power *n*.
 
 :returns: The powered word
 :rtype: List[int]
-
-:exceptions: This function guarantees not to throw a ``LibsemigroupsError``.
 )pbdoc");
     m.def(
         "prod",


### PR DESCRIPTION
This PR removes instances of `This function guarantees not to throw a ``LibsemigroupsError``.` and `This function is guaranteed never to throw.`