### PR TITLE
Update cpplint config

### DIFF
--- a/src/CPPLINT.cfg
+++ b/src/CPPLINT.cfg
@@ -2,9 +2,9 @@ set noparent
 filter = -build/c++11,
 filter = -build/c++15,
 filter = -build/include_subdir,
-filter = -runtime/indentation_namespace,
-filter = -runtime/references,
 filter = -build/include,
 filter = -readability/todo,
 filter = -runtime/printf
+filter = -runtime/references,
+filter = -whitespace/indent_namespace,
 linelength = 80


### PR DESCRIPTION
On 06/10/24, `cpplint` released version 2.0.0. Amongst [other changes](https://github.com/cpplint/cpplint/blob/develop/CHANGELOG.rst), this seemingly changed some of the names of the filters. This PR updates the names of our filters, and puts them in alphabetical order.