### PR TITLE
Handle returning `POSITIVE_INFINITY` in `Paths`

### DIFF
--- a/docs/source/data-structures/misc/constants.rst
+++ b/docs/source/data-structures/misc/constants.rst
@@ -4,38 +4,46 @@
 
    The full license is in the file LICENSE, distributed with this software.
 
-.. currentmodule:: libsemigroups_pybind11
+.. currentmodule:: _libsemigroups_pybind11
 
 Constants
 =========
 
 This page describes some of the constants used in ``libsemigroups_pybind11``.
 
-.. autodata:: UNDEFINED
+.. autoclass:: Undefined
 
-    This variable is used to indicate that a value is undefined. :any:`UNDEFINED`
-    is comparable with any integral value (signed or unsigned) or constant via
-    ``==`` and ``!=`` but not via ``<`` or ``>``.
+    .. autodata:: UNDEFINED
 
-.. autodata:: POSITIVE_INFINITY
+        This variable is used to indicate that a value is undefined. :any:`UNDEFINED`
+        is comparable with any integral value (signed or unsigned) or constant via
+        ``==`` and ``!=`` but not via ``<`` or ``>``.
 
-    This variable represents :math:`\infty`. :any:`POSITIVE_INFINITY` is
-    comparable via ``==``, ``!=``, ``<``, ``>`` with any integral value (signed or
-    unsigned) and with  :any:`NEGATIVE_INFINITY`, and is comparable to any other
-    constant via ``==`` and ``!=``, but not by ``<`` and ``>``.
+.. autoclass:: PositiveInfinity
 
-.. autodata:: LIMIT_MAX
+    .. autodata:: POSITIVE_INFINITY
 
-    This variable represents the maximum value that certain function
-    parameters can have. :any:`LIMIT_MAX` is comparable via ``==``, ``!=``, ``<``, ``>``
-    with any integral value (signed or unsigned), and is comparable to any
-    other constant via ``==`` and ``!=``, but not by ``<`` and ``>``.
+        This variable of type :class:`_libsemigroups_pybind11.PositiveInfinity` represents :math:`\infty`. :any:`POSITIVE_INFINITY` is
+        comparable via ``==``, ``!=``, ``<``, ``>`` with any integral value (signed or
+        unsigned) and with  :any:`NEGATIVE_INFINITY`, and is comparable to any other
+        constant via ``==`` and ``!=``, but not by ``<`` and ``>``.
 
-.. autodata:: NEGATIVE_INFINITY
+.. autoclass:: LimitMax
 
-    This variable represents :math:`-\infty`. :any:`NEGATIVE_INFINITY` is
-    comparable via ``==``, ``!=``, ``<``, ``>`` with any signed integral value and
-    with :any:`POSITIVE_INFINITY`, and is comparable to any other constant via
-    ``==`` and ``!=``.
+    .. autodata:: LIMIT_MAX
+
+        This variable represents the maximum value that certain function
+        parameters can have. :any:`LIMIT_MAX` is comparable via ``==``, ``!=``, ``<``, ``>``
+        with any integral value (signed or unsigned), and is comparable to any
+        other constant via ``==`` and ``!=``, but not by ``<`` and ``>``.
+
+.. autoclass:: NegativeInfinity
+
+    .. autodata:: NEGATIVE_INFINITY
+
+        This variable represents :math:`-\infty`. :any:`NEGATIVE_INFINITY` is
+        comparable via ``==``, ``!=``, ``<``, ``>`` with any signed integral value and
+        with :any:`POSITIVE_INFINITY`, and is comparable to any other constant via
+        ``==`` and ``!=``.
 
   

--- a/docs/source/data-structures/word-graph/paths/paths.rst
+++ b/docs/source/data-structures/word-graph/paths/paths.rst
@@ -4,7 +4,7 @@
 
     The full license is in the file LICENSE, distributed with this software.
 
-.. currentmodule:: _libsemigroups_pybind11
+.. currentmodule:: libsemigroups_pybind11
 
 The Paths class
 ===============
@@ -29,7 +29,7 @@ Contents
 	 Paths.order
 	 Paths.source
 	 Paths.target
-	 Paths.word_graph	
+	 Paths.word_graph
 
 Full API
 --------

--- a/libsemigroups_pybind11/__init__.py
+++ b/libsemigroups_pybind11/__init__.py
@@ -92,8 +92,8 @@ from .transf import (
     left_one,
 )
 
-# The following are imported from path since we modify the method _count to
-# return the POSITIVE_INFINITY object where applicable.
+# The following are imported from path since we modify the methods count and max
+# to return the POSITIVE_INFINITY object where applicable.
 from .paths import Paths, ReversiblePaths
 
 # The following fools sphinx into thinking that MatrixKind is not an alias.

--- a/libsemigroups_pybind11/detail/decorators.py
+++ b/libsemigroups_pybind11/detail/decorators.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024 J. D. Mitchell
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+
+# pylint: disable=no-member, protected-access
+
+"""
+This package provides decorators for the implementation of
+libsemigroups_pybind11.
+"""
+
+from functools import wraps
+
+from _libsemigroups_pybind11 import (
+    UNDEFINED as _UNDEFINED,
+    POSITIVE_INFINITY as _POSITIVE_INFINITY,
+)
+
+
+def copydoc(original):
+    """
+    Decorator that can be used to copy the doc from one function to another,
+    for example:
+
+    @copydoc(Transf1.__init__)
+    def __init___(self):
+       pass
+    """
+
+    original_doc = original.__doc__
+
+    if original_doc.startswith(original.__name__):
+        original_doc = "\n".join(original_doc.split("\n")[2:])
+
+    def wrapper(target):
+        target.__doc__ = original_doc
+        return target
+
+    return wrapper
+
+
+def may_return_undefined(func):
+    """
+    This function is a decorator for functions/methods that might return
+    UNDEFINED (as an integer, since there's no other option in C++), and which
+    should return the UNDEFINED object.
+    """
+    vals = tuple(2 ** (2**n) - 1 for n in range(3, 7))
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        if result in vals:
+            return _UNDEFINED
+        return result
+
+    return wrapper
+
+
+def may_return_positive_infinity(func):
+    """
+    This function is a decorator for functions/methods that might return
+    POSITIVE_INFINITY (as an integer, since there's no other option in C++), and which
+    should return the POSITIVE_INFINITY object.
+    """
+    vals = tuple(2 ** (2**n) - 2 for n in range(3, 7))
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        result = func(self, *args, **kwargs)
+        if result in vals:
+            return _POSITIVE_INFINITY
+        return result
+
+    return wrapper

--- a/libsemigroups_pybind11/paths.py
+++ b/libsemigroups_pybind11/paths.py
@@ -13,80 +13,16 @@ This package provides the user-facing python part of libsemigroups_pybind11 for
 the libsemigroups::paths namespace from libsemigroups.
 """
 
-from typing import Union
-
 from _libsemigroups_pybind11 import (
     Paths,
     ReversiblePaths,
-    POSITIVE_INFINITY,
-    PositiveInfinity,
 )
 
-
-def count(p: Union[Paths, ReversiblePaths]) -> Union[int, PositiveInfinity]:
-    """
-    Get the size of the range. This function returns the number of paths
-    remaining in the range (in particular, if :any:`next` is called then the
-    return value of :any:`count` decreases by ``1``).
-
-    :returns:
-       The number of paths remaining in the range.
-    :rtype:
-       int | PositiveInfinity
-
-    :raises LibsemigroupsError: if ``source() == UNDEFINED``.
-    """
-    result = p._count()
-    if result == POSITIVE_INFINITY:
-        return POSITIVE_INFINITY
-    return result
+from .detail.decorators import may_return_positive_infinity
 
 
-def max_method(*args):
-    """
-    max(*args, **kwargs)
+Paths.count = may_return_positive_infinity(Paths.count)
+Paths.max = may_return_positive_infinity(Paths.max)
 
-        Overloaded function.
-
-        .. py:method:: max(self: Paths) -> int | POSITIVE_INFINITY
-            :noindex:
-
-            Get the maximum length of path in the range. This function returns the
-            current maximum length of paths in the range. The initial value is
-            :any:`POSITIVE_INFINITY`.
-
-            :returns:
-               The maximum length of paths in the range.
-
-            :rtype:
-               int | PositiveInfinity
-
-        .. py:method:: max(self: Paths, val: int | POSITIVE_INFINITY) -> Paths
-            :noindex:
-
-            Set the maximum length of path in the range.
-
-            This function can be used to set the maximum length of path that will be
-            contained in the range. If this function is not called, then the range will
-            contain paths of unbounded length (possibly infinitely many).
-
-            :param val: the maximum path length.
-            :type val: int
-
-            :returns: ``self``.
-            :rtype: Paths
-    """
-    if len(args) == 1:
-        result = args[0]._max()
-        if result == POSITIVE_INFINITY:
-            return POSITIVE_INFINITY
-        return result
-    if len(args) > 1:
-        return args[0]._max(*args[1:])
-    raise TypeError
-
-
-Paths.count = count
-Paths.max = max_method
-ReversiblePaths.count = count
-ReversiblePaths.max = max_method
+ReversiblePaths.count = may_return_positive_infinity(ReversiblePaths.count)
+ReversiblePaths.max = may_return_positive_infinity(ReversiblePaths.max)

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -131,11 +131,25 @@ are no more paths in the range, and ``False`` otherwise.
 :raises LibsemigroupsError: if ``source() == UNDEFINED``.
 )pbdoc");
 
-    // _count's doc is in paths.py
-    thing1.def("_count", [](Paths_& p) {
-      p.throw_if_source_undefined();
-      return p.count();
-    });
+    thing1.def(
+        "count",
+        [](Paths_& p) {
+          p.throw_if_source_undefined();
+          return p.count();
+        },
+        R"pbdoc(
+:sig=(self: Paths) -> int | PositiveInfinity:
+Get the size of the range. This function returns the number of paths
+remaining in the range (in particular, if :any:`next` is called then the
+return value of :any:`count` decreases by ``1``).
+
+:returns:
+   The number of paths remaining in the range.
+:rtype:
+   int | PositiveInfinity
+
+:raises LibsemigroupsError: if ``source() == UNDEFINED``.
+    )pbdoc");
     thing1.def("current_target",
                &Paths_::current_target,
                R"pbdoc(
@@ -166,15 +180,51 @@ Get the current path in the range.
 
 :raises LibsemigroupsError: if ``source() == UNDEFINED``.
 )pbdoc");
-    // Same issue as with _count
-    thing1.def("_max", [](Paths_ const& self) { return self.max(); });
-    thing1.def("_max",
-               [](Paths_& self, PositiveInfinity const& val) -> Paths_& {
-                 return self.max(val);
-               });
-    thing1.def("_max", [](Paths_& self, size_type val) -> Paths_& {
-      return self.max(val);
-    });
+    thing1.def(
+        "max",
+        [](Paths_ const& self) { return self.max(); },
+        R"pbdoc(
+:sig=(self: Paths) -> int | PositiveInfinity:
+:only-document-once:
+Get the maximum length of path in the range.
+
+This function returns the current maximum length of paths in the range.
+The initial value is :any:`POSITIVE_INFINITY`.
+
+:returns:
+   The maximum length of paths in the range.
+
+:rtype:
+   int | PositiveInfinity
+)pbdoc");
+    thing1.def(
+        "max",
+        [](Paths_& self, PositiveInfinity const& val) -> Paths_& {
+          return self.max(val);
+        },
+        R"pbdoc(
+:sig=(self: Paths, val: int | PositiveInfinity) -> Paths:
+:only-document-once:
+Set the maximum length of path in the range.
+
+This function can be used to set the maximum length of path that will be
+contained in the range. If this function is not called, then the range will
+contain paths of unbounded length (possibly infinitely many).
+
+:param val: the maximum path length.
+:type val: int
+
+:returns: ``self``.
+:rtype: Paths
+)pbdoc");
+    thing1.def(
+        "max",
+        [](Paths_& self, size_type val) -> Paths_& { return self.max(val); },
+        py::arg("val"),
+        R"pbdoc(
+:sig=(self: Paths, val: int | PositiveInfinity) -> Paths:
+:only-document-once:
+)pbdoc");
     thing1.def(
         "min",
         [](Paths_ const& self) { return self.min(); },
@@ -408,11 +458,25 @@ are no more paths in the range, and ``False`` otherwise.
 
 :raises LibsemigroupsError: if ``source() == UNDEFINED``.
 )pbdoc");
-    // _count's doc is in paths.py
-    thing2.def("_count", [](ReversiblePaths_& p) {
-      p.throw_if_source_undefined();
-      return p.count();
-    });
+    thing2.def(
+        "count",
+        [](ReversiblePaths_& p) {
+          p.throw_if_source_undefined();
+          return p.count();
+        },
+        R"pbdoc(
+:sig=(self: ReversiblePaths) -> int | PositiveInfinity:
+Get the size of the range. This function returns the number of paths
+remaining in the range (in particular, if :any:`next` is called then the
+return value of :any:`count` decreases by ``1``).
+
+:returns:
+   The number of paths remaining in the range.
+:rtype:
+   int | PositiveInfinity
+
+:raises LibsemigroupsError: if ``source() == UNDEFINED``.
+)pbdoc");
     thing2.def("current_target",
                &ReversiblePaths_::current_target,
                R"pbdoc(
@@ -443,14 +507,51 @@ Get the current path in the range.
 
 :raises LibsemigroupsError: if ``source() == UNDEFINED``.
 )pbdoc");
-    thing2.def("_max", [](ReversiblePaths_ const& self) { return self.max(); });
-    thing2.def("_max",
-               [](ReversiblePaths_& self, size_type val) -> ReversiblePaths_& {
-                 return self.max(val);
-               });
-    thing2.def("_max",
-               [](ReversiblePaths_& self, PositiveInfinity const& val)
-                   -> ReversiblePaths_& { return self.max(val); });
+    thing2.def(
+        "max",
+        [](ReversiblePaths_ const& self) { return self.max(); },
+        R"pbdoc(
+:sig=(self: ReversiblePaths) -> int | PositiveInfinity:
+:only-document-once:
+Get the maximum length of path in the range.
+
+This function returns the current maximum length of paths in the range.
+The initial value is :any:`POSITIVE_INFINITY`.
+
+:returns:
+   The maximum length of paths in the range.
+
+:rtype:
+   int | PositiveInfinity
+)pbdoc");
+    thing2.def(
+        "max",
+        [](ReversiblePaths_& self, size_type val) -> ReversiblePaths_& {
+          return self.max(val);
+        },
+        R"pbdoc(
+:sig=(self: ReversiblePaths, val: int | PositiveInfinity) -> ReversiblePaths:
+:only-document-once:
+Set the maximum length of path in the range.
+
+This function can be used to set the maximum length of path that will be
+contained in the range. If this function is not called, then the range will
+contain paths of unbounded length (possibly infinitely many).
+
+:param val: the maximum path length.
+:type val: int
+
+:returns: ``self``.
+:rtype: Paths
+)pbdoc");
+    thing2.def(
+        "max",
+        [](ReversiblePaths_& self, PositiveInfinity const& val)
+            -> ReversiblePaths_& { return self.max(val); },
+        R"pbdoc(
+:sig=(self: ReversiblePaths, val: int | PositiveInfinity) -> ReversiblePaths:
+:only-document-once:
+)pbdoc");
     thing2.def(
         "min",
         [](ReversiblePaths_ const& self) { return self.min(); },


### PR DESCRIPTION
This PR updates the `Paths` class. Specifically, it defines some decorators, one of which allows a function to return `POSITIVE_INFINITY`. Furthermore, it documents the classes of each of the constants we define, so that more types in function signatures get converted to URLs. 