### PR TITLE
Add `SchreierSims` for v1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -179,6 +179,7 @@ class_specific_replacements = {
         ("Transf", "Perm"),
     ],
     "FroidurePinPBR": [(r"\bPBR\b", "Element")],
+    "SchreierSimsPerm1": [(r"\bPerm1\b", "Element")],
     "ReversiblePaths": [(r"\bPaths\b", "ReversiblePaths")],
 }
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -71,6 +71,7 @@ See the installation instructions:
    main-algorithms/knuth-bendix/index
    main-algorithms/konieczny/index
    main-algorithms/radoszewski-rytter/index
+   main-algorithms/schreier-sims/index
    main-algorithms/stephen/index
    main-algorithms/todd-coxeter/index
    main-algorithms/ukkonen/index

--- a/docs/source/main-algorithms/schreier-sims/index.rst
+++ b/docs/source/main-algorithms/schreier-sims/index.rst
@@ -8,7 +8,7 @@ Schreier-Sims
 =============
 
 This page describes the functionality related to the Schreier-Sims algorithm for
-computing a base and strong generating set of a permutation group in
+computing a stabilizer chain of a permutation group in
 ``libsemigroups_pybind11``.
 
 

--- a/docs/source/main-algorithms/schreier-sims/index.rst
+++ b/docs/source/main-algorithms/schreier-sims/index.rst
@@ -1,0 +1,19 @@
+.. Copyright (c) 2024 Joseph Edwards
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+Schreier-Sims
+=============
+
+This page describes the functionality related to the Schreier-Sims algorithm for
+computing a base and strong generating set of a permutation group in
+``libsemigroups_pybind11``.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   schreier-sims
+   schreier-sims-helpers

--- a/docs/source/main-algorithms/schreier-sims/schreier-sims-helpers.rst
+++ b/docs/source/main-algorithms/schreier-sims/schreier-sims-helpers.rst
@@ -1,0 +1,33 @@
+.. Copyright (c) 2024 Joseph Edwards
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+Schreier-Sims helper functions
+==============================
+
+This page contains the documentation for various helper functions for
+manipulating :any:`SchreierSims` objects.
+
+Contents
+--------
+
+In ``libsemigroups_pybind11``:
+
+.. currentmodule:: libsemigroups_pybind11.schreier_sims
+
+.. autosummary::
+   :nosignatures:
+
+    intersection
+
+
+Full API
+--------
+
+.. currentmodule:: libsemigroups_pybind11
+
+.. automodule:: libsemigroups_pybind11.schreier_sims
+   :members:
+   :imported-members:

--- a/docs/source/main-algorithms/schreier-sims/schreier-sims-helpers.rst
+++ b/docs/source/main-algorithms/schreier-sims/schreier-sims-helpers.rst
@@ -8,7 +8,7 @@ Schreier-Sims helper functions
 ==============================
 
 This page contains the documentation for various helper functions for
-manipulating :any:`SchreierSims` objects.
+manipulating :any:`SchreierSimsPerm1` objects.
 
 Contents
 --------

--- a/docs/source/main-algorithms/schreier-sims/schreier-sims.rst
+++ b/docs/source/main-algorithms/schreier-sims/schreier-sims.rst
@@ -1,0 +1,51 @@
+.. Copyright (c) 2023-2024 J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+.. currentmodule:: libsemigroups_pybind11
+
+The Schreier-Sims class
+=======================
+
+.. autoclass:: SchreierSims
+   :doc-only:
+   :class-doc-from: class
+
+Contents
+--------
+
+.. autosummary::
+    :nosignatures:
+
+    ~SchreierSims
+    SchreierSims.add_base_point
+    SchreierSims.add_generator
+    SchreierSims.base
+    SchreierSims.base_size
+    SchreierSims.contains
+    SchreierSims.contains_no_run
+    SchreierSims.empty
+    SchreierSims.finished
+    SchreierSims.generator
+    SchreierSims.init
+    SchreierSims.inverse_transversal_element
+    SchreierSims.number_of_generators
+    SchreierSims.number_of_strong_generators
+    SchreierSims.one
+    SchreierSims.orbit_lookup
+    SchreierSims.run
+    SchreierSims.sift
+    SchreierSims.sift_inplace
+    SchreierSims.size
+    SchreierSims.strong_generator
+    SchreierSims.transversal_element
+
+Full API
+--------
+
+.. autoclass:: SchreierSims
+   :members:
+   :class-doc-from: init
+

--- a/docs/source/main-algorithms/schreier-sims/schreier-sims.rst
+++ b/docs/source/main-algorithms/schreier-sims/schreier-sims.rst
@@ -9,7 +9,7 @@
 The Schreier-Sims class
 =======================
 
-.. autoclass:: SchreierSims
+.. autoclass:: SchreierSimsPerm1
    :doc-only:
    :class-doc-from: class
 
@@ -19,34 +19,33 @@ Contents
 .. autosummary::
     :nosignatures:
 
-    ~SchreierSims
-    SchreierSims.add_base_point
-    SchreierSims.add_generator
-    SchreierSims.base
-    SchreierSims.base_size
-    SchreierSims.contains
-    SchreierSims.current_size
-    SchreierSims.currently_contains
-    SchreierSims.empty
-    SchreierSims.finished
-    SchreierSims.generator
-    SchreierSims.init
-    SchreierSims.inverse_transversal_element
-    SchreierSims.number_of_generators
-    SchreierSims.number_of_strong_generators
-    SchreierSims.one
-    SchreierSims.orbit_lookup
-    SchreierSims.run
-    SchreierSims.sift
-    SchreierSims.sift_inplace
-    SchreierSims.size
-    SchreierSims.strong_generator
-    SchreierSims.transversal_element
+    SchreierSimsPerm1.add_base_point
+    SchreierSimsPerm1.add_generator
+    SchreierSimsPerm1.base
+    SchreierSimsPerm1.base_size
+    SchreierSimsPerm1.contains
+    SchreierSimsPerm1.current_size
+    SchreierSimsPerm1.currently_contains
+    SchreierSimsPerm1.empty
+    SchreierSimsPerm1.finished
+    SchreierSimsPerm1.generator
+    SchreierSimsPerm1.init
+    SchreierSimsPerm1.inverse_transversal_element
+    SchreierSimsPerm1.number_of_generators
+    SchreierSimsPerm1.number_of_strong_generators
+    SchreierSimsPerm1.one
+    SchreierSimsPerm1.orbit_lookup
+    SchreierSimsPerm1.run
+    SchreierSimsPerm1.sift
+    SchreierSimsPerm1.sift_inplace
+    SchreierSimsPerm1.size
+    SchreierSimsPerm1.strong_generator
+    SchreierSimsPerm1.transversal_element
 
 Full API
 --------
 
-.. autoclass:: SchreierSims
+.. autoclass:: SchreierSimsPerm1
    :members:
    :class-doc-from: init
 

--- a/docs/source/main-algorithms/schreier-sims/schreier-sims.rst
+++ b/docs/source/main-algorithms/schreier-sims/schreier-sims.rst
@@ -4,7 +4,7 @@
 
    The full license is in the file LICENSE, distributed with this software.
 
-.. currentmodule:: libsemigroups_pybind11
+.. currentmodule:: _libsemigroups_pybind11
 
 The Schreier-Sims class
 =======================
@@ -14,7 +14,7 @@ The Schreier-Sims class
    :class-doc-from: class
 
 Contents
---------
+-------- 
 
 .. autosummary::
     :nosignatures:
@@ -25,7 +25,8 @@ Contents
     SchreierSims.base
     SchreierSims.base_size
     SchreierSims.contains
-    SchreierSims.contains_no_run
+    SchreierSims.current_size
+    SchreierSims.currently_contains
     SchreierSims.empty
     SchreierSims.finished
     SchreierSims.generator

--- a/etc/replace-strings-in-doc.py
+++ b/etc/replace-strings-in-doc.py
@@ -54,6 +54,7 @@ replacements = {
     "ImageRightActionPPerm1PPerm1": "ImageRightAction",
     "_libsemigroups_pybind11.FroidurePinBase": "FroidurePinBase",
     "FroidurePinPBR": "FroidurePin",
+    "SchreierSimsPerm1": "SchreierSims",
 }
 files = all_html_files(html_path)
 

--- a/libsemigroups_pybind11/__init__.py
+++ b/libsemigroups_pybind11/__init__.py
@@ -66,7 +66,6 @@ try:
         PBR,
         Ukkonen,
         tril,
-        SchreierSims,
     )
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(

--- a/libsemigroups_pybind11/__init__.py
+++ b/libsemigroups_pybind11/__init__.py
@@ -104,3 +104,4 @@ MatrixKind.__module__ = __name__
 MatrixKind.__name__ = "MatrixKind"
 
 from .froidure_pin import FroidurePin
+from .schreier_sims import SchreierSims

--- a/libsemigroups_pybind11/__init__.py
+++ b/libsemigroups_pybind11/__init__.py
@@ -66,6 +66,7 @@ try:
         PBR,
         Ukkonen,
         tril,
+        SchreierSims,
     )
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(

--- a/libsemigroups_pybind11/action.py
+++ b/libsemigroups_pybind11/action.py
@@ -56,7 +56,7 @@ class Action(Runner):  # pylint: disable=invalid-name, too-many-instance-attribu
     src/action.cpp!
     """
 
-    py_to_cxx_type_dict = {
+    _py_to_cxx_type_dict = {
         (BMat8, BMat8, ImageRightAction, side.right): _RightActionBMat8BMat8,
         (BMat8, BMat8, ImageLeftAction, side.left): _LeftActionBMat8BMat8,
         (PPerm, PPerm, ImageRightAction, side.right): {

--- a/libsemigroups_pybind11/adapters.py
+++ b/libsemigroups_pybind11/adapters.py
@@ -88,7 +88,7 @@ class ImageRightAction(_ImageAction):
         * *Point* -- the type of the points acted on
     """
 
-    py_to_cxx_type_dict = {
+    _py_to_cxx_type_dict = {
         (_BMat8, _BMat8): _ImageRightActionBMat8BMat8,
         (PPerm, PPerm): {
             (_PPerm1, _PPerm1): _ImageRightActionPPerm1PPerm1,
@@ -109,7 +109,7 @@ class ImageLeftAction(_ImageAction):  # pylint: disable=invalid-name
         * *Point* -- the type of the points acted on
     """
 
-    py_to_cxx_type_dict = {
+    _py_to_cxx_type_dict = {
         (_BMat8, _BMat8): _ImageLeftActionBMat8BMat8,
         (PPerm, PPerm): {
             (_PPerm1, _PPerm1): _ImageLeftActionPPerm1PPerm1,

--- a/libsemigroups_pybind11/adapters.py
+++ b/libsemigroups_pybind11/adapters.py
@@ -41,9 +41,9 @@ class _ImageAction(CxxWrapper):
         super().__init__(("Element", "Point"), **kwargs)
 
     def _init_cxx_obj(self: Self, elt: Any, pt: Any) -> Any:
-        cpp_obj_t = self._cxx_obj_type_from(samples=(elt, pt))
-        if self._cxx_obj is None or not isinstance(self._cxx_obj, cpp_obj_t):
-            self._cxx_obj = cpp_obj_t()
+        cxx_obj_t = self._cxx_obj_type_from(samples=(elt, pt))
+        if self._cxx_obj is None or not isinstance(self._cxx_obj, cxx_obj_t):
+            self._cxx_obj = cxx_obj_t()
         return self._cxx_obj
 
     def __call__(  # pylint: disable=inconsistent-return-statements

--- a/libsemigroups_pybind11/detail/cxx_wrapper.py
+++ b/libsemigroups_pybind11/detail/cxx_wrapper.py
@@ -103,6 +103,15 @@ class CxxWrapper(metaclass=abc.ABCMeta):
             return self._cxx_obj.__repr__()
         return ""
 
+    def __copy__(self: Self) -> str:
+        if self._cxx_obj is not None:
+            if hasattr(self._cxx_obj, "__copy__"):
+                return self._cxx_obj.__copy__()
+            raise NotImplementedError(
+                f"{type(self._cxx_obj)} has no member named __copy__"
+            )
+        raise NameError("_cxx_obj has not been defined")
+
     @property
     def _py_to_cxx_type_dict(self: Self) -> dict:
         return self.__class__.__lookup

--- a/libsemigroups_pybind11/detail/cxx_wrapper.py
+++ b/libsemigroups_pybind11/detail/cxx_wrapper.py
@@ -112,6 +112,15 @@ class CxxWrapper(metaclass=abc.ABCMeta):
             )
         raise NameError("_cxx_obj has not been defined")
 
+    def __eq__(self: Self, that) -> bool:
+        if self._cxx_obj is not None:
+            if hasattr(self._cxx_obj, "__eq__"):
+                return self._cxx_obj.__eq__(that)
+            raise NotImplementedError(
+                f"{type(self._cxx_obj)} has no member named __eq__"
+            )
+        raise NameError("_cxx_obj has not been defined")
+
     @property
     def _py_to_cxx_type_dict(self: Self) -> dict:
         return self.__class__.__lookup

--- a/libsemigroups_pybind11/detail/cxx_wrapper.py
+++ b/libsemigroups_pybind11/detail/cxx_wrapper.py
@@ -65,7 +65,7 @@ class CxxWrapper(metaclass=abc.ABCMeta):
         # the next line ensures we get the values in the same order as in
         # lookup
         values = tuple(kwargs[x] for x in expected_kwargs)
-        lookup = self.py_to_cxx_type_dict
+        lookup = self._py_to_cxx_type_dict
         if values in lookup:
             for key, val in kwargs.items():
                 setattr(self, key, val)
@@ -104,18 +104,18 @@ class CxxWrapper(metaclass=abc.ABCMeta):
         return ""
 
     @property
-    def py_to_cxx_type_dict(self: Self) -> dict:
+    def _py_to_cxx_type_dict(self: Self) -> dict:
         return self.__class__.__lookup
 
     # TODO type annotations
-    @py_to_cxx_type_dict.setter
-    def py_to_cxx_type_dict(self: Self, value):
+    @_py_to_cxx_type_dict.setter
+    def _py_to_cxx_type_dict(self: Self, value):
         # TODO check that value is a dict of the correct structure
         self.__class__.__lookup = value
 
     def _cxx_obj_type_from(self: Self, samples=(), types=()) -> Any:
         py_types = tuple([type(x) for x in samples] + list(types))
-        lookup = self.py_to_cxx_type_dict
+        lookup = self._py_to_cxx_type_dict
         if py_types not in lookup:
             raise ValueError(
                 f"unexpected keyword argument combination {py_types}, "

--- a/libsemigroups_pybind11/detail/cxx_wrapper.py
+++ b/libsemigroups_pybind11/detail/cxx_wrapper.py
@@ -124,10 +124,10 @@ class CxxWrapper(metaclass=abc.ABCMeta):
         if not isinstance(lookup[py_types], dict):
             return lookup[py_types]
         lookup = lookup[py_types]
-        cpp_types = tuple([type(to_cxx(x)) for x in samples] + list(types))
-        if cpp_types not in lookup:
+        cxx_types = tuple([type(to_cxx(x)) for x in samples] + list(types))
+        if cxx_types not in lookup:
             raise ValueError(
-                f"unexpected keyword argument combination {cpp_types}, "
+                f"unexpected keyword argument combination {cxx_types}, "
                 f"expected one of {lookup.keys()}"
             )
-        return lookup[cpp_types]
+        return lookup[cxx_types]

--- a/libsemigroups_pybind11/froidure_pin.py
+++ b/libsemigroups_pybind11/froidure_pin.py
@@ -132,12 +132,12 @@ class FroidurePin(CxxWrapper):  # pylint: disable=missing-class-docstring
             gens = args[0]
         else:
             gens = args
-        cpp_obj_t = self._cxx_obj_type_from(
+        cxx_obj_t = self._cxx_obj_type_from(
             samples=(to_cxx(gens[0]),),
         )
         self.Element = type(gens[0])
 
-        self._cxx_obj = cpp_obj_t([to_cxx(x) for x in gens])
+        self._cxx_obj = cxx_obj_t([to_cxx(x) for x in gens])
 
     @_returns_element
     def __getitem__(self: Self, i: int) -> Element:

--- a/libsemigroups_pybind11/froidure_pin.py
+++ b/libsemigroups_pybind11/froidure_pin.py
@@ -96,7 +96,7 @@ def _returns_element(method):
 
 
 class FroidurePin(CxxWrapper):  # pylint: disable=missing-class-docstring
-    py_to_cxx_type_dict = {
+    _py_to_cxx_type_dict = {
         (_Transf1,): _FroidurePinTransf1,
         (_Transf2,): _FroidurePinTransf2,
         (_Transf4,): _FroidurePinTransf4,

--- a/libsemigroups_pybind11/froidure_pin.py
+++ b/libsemigroups_pybind11/froidure_pin.py
@@ -123,7 +123,10 @@ class FroidurePin(CxxWrapper):  # pylint: disable=missing-class-docstring
     # C++ FroidurePin special methods
     ########################################################################
 
-    def __init__(  # pylint: disable=super-init-not-called
+    # TODO(1): This __init__ is identical to the SchreierSims __init__. It would
+    # probably be best to make an abstract base class from which all classes
+    # that construct using a list of generators inherit.
+    def __init__(  # pylint: disable=super-init-not-called, duplicate-code
         self: Self, *args
     ) -> None:
         if len(args) == 0:
@@ -154,10 +157,14 @@ class FroidurePin(CxxWrapper):  # pylint: disable=missing-class-docstring
     ########################################################################
 
     def current_elements(self: Self) -> Iterator:
-        return map(lambda x: to_py(self.Element, x), self._cxx_obj.current_elements())
+        return map(
+            lambda x: to_py(self.Element, x), self._cxx_obj.current_elements()
+        )
 
     def idempotents(self: Self) -> Iterator:
-        return map(lambda x: to_py(self.Element, x), self._cxx_obj.idempotents())
+        return map(
+            lambda x: to_py(self.Element, x), self._cxx_obj.idempotents()
+        )
 
     def sorted_elements(self: Self) -> Iterator:
         return map(

--- a/libsemigroups_pybind11/schreier_sims.py
+++ b/libsemigroups_pybind11/schreier_sims.py
@@ -14,11 +14,11 @@ the schreier_sims namespace from libsemigroups.
 """
 
 from functools import wraps
-from typing import List, TypeVar as _TypeVar
+from typing import TypeVar as _TypeVar
 from typing_extensions import Self
 
 from _libsemigroups_pybind11 import (
-    intersection,
+    intersection as _intersection,
     SchreierSimsPerm1 as _SchreierSimsPerm1,
     SchreierSimsPerm2 as _SchreierSimsPerm2,
     Perm1 as _Perm1,
@@ -93,9 +93,22 @@ class SchreierSims(CxxWrapper):
         return self._cxx_obj.one()
 
     @_returns_element
+    def sift(self: Self, x: Element) -> Element:
+        return self._cxx_obj.sift(to_cxx(x))
+
+    @_returns_element
     def strong_generator(self: Self, depth: int, index: int) -> Element:
         return self._cxx_obj.strong_generator(depth, index)
 
     @_returns_element
     def transversal_element(self: Self, depth: int, pt: int) -> Element:
         return self._cxx_obj.transversal_element(depth, pt)
+
+
+########################################################################
+# Helpers -- from schreier-sims.cpp
+########################################################################
+
+
+def intersection(U: SchreierSims, S: SchreierSims, T: SchreierSims):
+    return _intersection(to_cxx(U), to_cxx(S), to_cxx(T))

--- a/libsemigroups_pybind11/schreier_sims.py
+++ b/libsemigroups_pybind11/schreier_sims.py
@@ -13,4 +13,89 @@ This package provides the user-facing python part of libsemigroups_pybind11 for
 the schreier_sims namespace from libsemigroups.
 """
 
-from _libsemigroups_pybind11 import intersection
+from functools import wraps
+from typing import List, TypeVar as _TypeVar
+from typing_extensions import Self
+
+from _libsemigroups_pybind11 import (
+    intersection,
+    SchreierSimsPerm1 as _SchreierSimsPerm1,
+    SchreierSimsPerm2 as _SchreierSimsPerm2,
+    Perm1 as _Perm1,
+    Perm2 as _Perm2,
+    # Perm4 as _Perm4,
+)
+
+from .detail.cxx_wrapper import (
+    to_cxx,
+    to_py,
+    CxxWrapper,
+)
+
+Element = _TypeVar("Element")
+
+########################################################################
+# Decorators
+########################################################################
+
+
+def _returns_element(method):
+    @wraps(method)
+    def wrapper(self, *args):
+        return to_py(self.Element, method(self, *args))
+
+    return wrapper
+
+
+class SchreierSims(CxxWrapper):
+    _py_to_cxx_type_dict = {
+        (_Perm1,): _SchreierSimsPerm1,
+        (_Perm2,): _SchreierSimsPerm2,
+        # (_Perm4,): _SchreierSims,
+    }
+
+    ########################################################################
+    # C++ Constructors
+    ########################################################################
+
+    def __init__(
+        self: Self, *args
+    ) -> None:  # pylint: disable=super-init-not-called
+        if len(args) == 0:
+            raise ValueError("expected at least 1 argument, found 0")
+        if isinstance(args[0], list) and len(args) == 1:
+            gens = args[0]
+        else:
+            gens = args
+        cxx_obj_t = self._cxx_obj_type_from(
+            samples=(to_cxx(gens[0]),),
+        )
+        self.Element = type(gens[0])
+
+        self._cxx_obj = cxx_obj_t()
+        for gen in gens:
+            self._cxx_obj.add_generator(to_cxx(gen))
+
+    ########################################################################
+    # Methods returning an element
+    ########################################################################
+
+    @_returns_element
+    def generator(self: Self, index: int) -> Element:
+        return self._cxx_obj.generator(index)
+
+    @_returns_element
+    def inverse_transversal_element(self: Self, depth: int, pt: int) -> Element:
+        return self._cxx_obj.inverse_transversal_element(depth, pt)
+
+    @_returns_element
+    def one(self: Self) -> Element:
+        return self._cxx_obj.one()
+
+    @_returns_element
+    def strong_generator(self: Self, depth: int, index: int) -> Element:
+        return self._cxx_obj.strong_generator(depth, index)
+
+    @_returns_element
+    def transversal_element(self: Self, depth: int, pt: int) -> Element:
+        return self._cxx_obj.transversal_element(depth, pt)

--- a/libsemigroups_pybind11/schreier_sims.py
+++ b/libsemigroups_pybind11/schreier_sims.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024 Joseph Edwards
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+
+# pylint: disable=no-name-in-module, invalid-name, unused-import, fixme
+
+"""
+This package provides the user-facing python part of libsemigroups_pybind11 for
+the schreier_sims namespace from libsemigroups.
+"""
+
+from _libsemigroups_pybind11 import intersection

--- a/libsemigroups_pybind11/schreier_sims.py
+++ b/libsemigroups_pybind11/schreier_sims.py
@@ -7,6 +7,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 
 # pylint: disable=no-name-in-module, invalid-name, unused-import, fixme
+# pylint: disable=missing-function-docstring
 
 """
 This package provides the user-facing python part of libsemigroups_pybind11 for
@@ -47,7 +48,7 @@ def _returns_element(method):
     return wrapper
 
 
-class SchreierSims(CxxWrapper):
+class SchreierSims(CxxWrapper):  # pylint: disable=missing-class-docstring
     _py_to_cxx_type_dict = {
         (_Perm1,): _SchreierSimsPerm1,
         (_Perm2,): _SchreierSimsPerm2,
@@ -58,9 +59,9 @@ class SchreierSims(CxxWrapper):
     # C++ Constructors
     ########################################################################
 
-    def __init__(
+    def __init__(  # pylint: disable=super-init-not-called
         self: Self, *args
-    ) -> None:  # pylint: disable=super-init-not-called
+    ) -> None:
         if len(args) == 0:
             raise ValueError("expected at least 1 argument, found 0")
         if isinstance(args[0], list) and len(args) == 1:

--- a/libsemigroups_pybind11/schreier_sims.py
+++ b/libsemigroups_pybind11/schreier_sims.py
@@ -59,7 +59,10 @@ class SchreierSims(CxxWrapper):  # pylint: disable=missing-class-docstring
     # C++ Constructors
     ########################################################################
 
-    def __init__(  # pylint: disable=super-init-not-called
+    # TODO(1): This __init__ is identical to the FroidurePin __init__. It would
+    # probably be best to make an abstract base class from which all classes
+    # that construct using a list of generators inherit.
+    def __init__(  # pylint: disable=super-init-not-called, duplicate-code
         self: Self, *args
     ) -> None:
         if len(args) == 0:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,7 +151,7 @@ The valid values are:
     m.attr("LIBSEMIGROUPS_EIGEN_ENABLED")
         = static_cast<bool>(LIBSEMIGROUPS_EIGEN_ENABLED);
 #else
-    m.attr("LIBSEMIGROUPS_EIGEN_ENABLED") = false;
+    m.attr("LIBSEMIGROUPS_EIGEN_ENABLED")   = false;
 #endif
 
 #ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED
@@ -206,11 +206,12 @@ The valid values are:
     init_froidure_pin_base(m);
     init_ukkonen(m);
     init_froidure_pin(m);
+    init_schreier_sims(m);
 
 #ifdef VERSION_INFO
     m.attr("__version__") = VERSION_INFO;
 #else
-    m.attr("__version__") = "dev";
+    m.attr("__version__")                   = "dev";
 #endif
 
     ////////////////////////////////////////////////////////////////////////

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -54,6 +54,7 @@ namespace libsemigroups {
   void init_froidure_pin_base(py::module&);
   void init_ukkonen(py::module&);
   void init_froidure_pin(py::module&);
+  void init_schreier_sims(py::module&);
 
 }  // namespace libsemigroups
 

--- a/src/schreier-sims.cpp
+++ b/src/schreier-sims.cpp
@@ -88,40 +88,8 @@ the list *gens*.
       thing.def(py::init<SchreierSims_ const&>(), R"pbdoc(
       Default copy constructor.
 )pbdoc");
-      thing.def("__copy__", [](SchreierSims_ const& S) -> SchreierSims_ {
-        return SchreierSims_(S);
-      });
-      thing.def(
-          "copy1",
-          [](SchreierSims_ const& S) { return SchreierSims_(S); },
-          py::return_value_policy::automatic);
-      thing.def(
-          "copy2",
-          [](SchreierSims_ const& S) { return SchreierSims_(S); },
-          py::return_value_policy::automatic_reference);
-      thing.def(
-          "copy3",
-          [](SchreierSims_ const& S) { return SchreierSims_(S); },
-          py::return_value_policy::copy);
-      thing.def(
-          "copy4",
-          [](SchreierSims_ const& S) { return SchreierSims_(S); },
-          py::return_value_policy::move);
-      thing.def(
-          "copy5",
-          [](SchreierSims_ const& S) { return SchreierSims_(S); },
-          py::return_value_policy::reference);
-      thing.def(
-          "copy6",
-          [](SchreierSims_ const& S) { return SchreierSims_(S); },
-          py::return_value_policy::reference_internal);
-      thing.def(
-          "copy7",
-          [](SchreierSims_ const& S) { return SchreierSims_(S); },
-          py::return_value_policy::take_ownership);
-      thing.def("copy",
+      thing.def("__copy__",
                 [](SchreierSims_ const& S) { return SchreierSims_(S); });
-      thing.def("kill", [](SchreierSims_ const& S) { S.~SchreierSims(); });
       thing.def("add_base_point",
                 &SchreierSims_::add_base_point,
                 py::arg("pt"),
@@ -482,7 +450,7 @@ corresponding to the intersection of *S1* and *S2*.
 :raises LibsemigroupsError:  if *T* is not empty.
 )pbdoc");
     }  // bind_schreier_sims
-  }  // namespace
+  }    // namespace
 
   void init_schreier_sims(py::module& m) {
     // One call to bind is required per list of types

--- a/src/schreier-sims.cpp
+++ b/src/schreier-sims.cpp
@@ -46,12 +46,13 @@ namespace libsemigroups {
   namespace {
     template <size_t N>
     void bind_schreier_sims(py::module& m, std::string const& name) {
-      using SchreierSims_ = SchreierSims<N>;
+      using SchreierSims_ = SchreierSims<N, uint8_t, Perm<0, uint8_t>>;
 
       // TODO std::unique_ptr
-      py::class_<SchreierSims_> thing(m,
-                                      name.c_str(),
-                                      R"pbdoc(
+      py::class_<SchreierSims_, std::unique_ptr<SchreierSims_>> thing(
+          m,
+          name.c_str(),
+          R"pbdoc(
 This class implements a deterministic version of the Schreier-Sims algorithm
 acting on a relatively small number of points (< 1000).
 
@@ -462,7 +463,7 @@ This function finds the intersection of two permutation groups. It modifies the 
 
   void init_schreier_sims(py::module& m) {
     // One call to bind is required per list of types
-    bind_schreier_sims<256>(m, "SchreierSims");
+    bind_schreier_sims<255>(m, "SchreierSims");
   }
 
 }  // namespace libsemigroups

--- a/src/schreier-sims.cpp
+++ b/src/schreier-sims.cpp
@@ -56,7 +56,7 @@ namespace libsemigroups {
 This class implements a deterministic version of the Schreier-Sims algorithm
 acting on a relatively small number of points (< 1000).
 
-:example: 
+:example:
 
 .. doctest:: python
 
@@ -80,7 +80,7 @@ the list *gens*.
 :param gens: the list of generators.
 :type gens: List[Element]
 
-:raises LibsemigroupsError: if the generators do not have degree equal to 
+:raises LibsemigroupsError: if the generators do not have degree equal to
       :math:`255` or :math:`511`, or the number of generators exceeds the
       maximum capacity.
 )pbdoc");
@@ -88,10 +88,9 @@ the list *gens*.
       thing.def(py::init<SchreierSims_ const&>(), R"pbdoc(
       Default copy constructor.
 )pbdoc");
-      thing.def(
-          "__copy__",
-          [](SchreierSims_ const& S) { return SchreierSims_(S); },
-          py::return_value_policy::automatic);
+      thing.def("__copy__", [](SchreierSims_ const& S) -> SchreierSims_ {
+        return SchreierSims_(S);
+      });
       thing.def(
           "copy1",
           [](SchreierSims_ const& S) { return SchreierSims_(S); },
@@ -154,8 +153,8 @@ not already an element of the group represented by the Schreier-Sims object.
 :returns:  ``True`` if *x* is added as a generator and ``False`` if it is not.
 :rtype: bool
 
-:raises LibsemigroupsError:  if the degree of *x* is not equal to :math:`255` 
-      or :math:`511`, or if ``self`` already contains the maximum number of 
+:raises LibsemigroupsError:  if the degree of *x* is not equal to :math:`255`
+      or :math:`511`, or if ``self`` already contains the maximum number of
       elements.
 
 :complexity: Constant
@@ -275,7 +274,7 @@ Get an inverse of a transversal element.
 This function returns the transversal element at depth *depth* which sends *pt*
 to the basepoint.
 
-:param depth: the depth. 
+:param depth: the depth.
 :type depth: int
 
 :param pt: the point to map to the base point under the inverse transversal
@@ -337,7 +336,7 @@ Returns a const reference to the identity.
                 R"pbdoc(
 Check if a point is in the orbit of a basepoint.
 
-:param depth: the depth. 
+:param depth: the depth.
 :type depth: int
 
 :param pt: the point.
@@ -358,7 +357,7 @@ Check if a point is in the orbit of a basepoint.
 Run the Schreier-Sims algorithm.
 
 
-:complexity:  :math:`O(N^2\log^3|G|+|T|N^2\log|G|)` time and 
+:complexity:  :math:`O(N^2\log^3|G|+|T|N^2\log|G|)` time and
       :math:`O(N^2\log|G|+|T|N)` space, where ``N`` is the degree of the
       generators, :math:`|G|` is the size of the group and :math:`|T|` is the
       number of generators of the group.
@@ -415,7 +414,7 @@ Get a strong generator.
 
 This function returns the generator with a given depth and index.
 
-:param depth: the depth. 
+:param depth: the depth.
 :type depth: int
 
 :param index: the index of the generator to return.
@@ -440,7 +439,7 @@ Get an transversal element.
 This function returns the transversal element at depth *depth* which sends the
 corresponding basepoint to the point *pt*.
 
-:param depth: the depth. 
+:param depth: the depth.
 :type depth: int
 
 :param pt: the image of the base point under the traversal.
@@ -467,14 +466,14 @@ corresponding basepoint to the point *pt*.
           R"pbdoc(
 Find the intersection of two permutation groups.
 
-This function finds the intersection of two permutation groups. 
+This function finds the intersection of two permutation groups.
 It modifies the first parameter *T* to be the :any:`SchreierSimsPerm1` object
 corresponding to the intersection of *S1* and *S2*.
 
-:param T: an empty SchreierSims object that will hold the result. 
+:param T: an empty SchreierSims object that will hold the result.
 :type T: SchreierSimsPerm1
 
-:param S1: the first group of the intersection. 
+:param S1: the first group of the intersection.
 :type S1: SchreierSimsPerm1
 
 :param S2: the second group of the intersection.
@@ -483,7 +482,7 @@ corresponding to the intersection of *S1* and *S2*.
 :raises LibsemigroupsError:  if *T* is not empty.
 )pbdoc");
     }  // bind_schreier_sims
-  }    // namespace
+  }  // namespace
 
   void init_schreier_sims(py::module& m) {
     // One call to bind is required per list of types

--- a/src/schreier-sims.cpp
+++ b/src/schreier-sims.cpp
@@ -44,14 +44,15 @@ namespace py = pybind11;
 namespace libsemigroups {
 
   namespace {
-    template <size_t N>
+    template <size_t N, typename Point, typename Element>
     void bind_schreier_sims(py::module& m, std::string const& name) {
-      using SchreierSims_ = SchreierSims<N, uint8_t, Perm<0, uint8_t>>;
+      using SchreierSims_ = SchreierSims<N, Point, Element>;
 
-      // TODO std::unique_ptr
+      std::string pyclass_name = std::string("SchreierSims") + name;
+
       py::class_<SchreierSims_, std::unique_ptr<SchreierSims_>> thing(
           m,
-          name.c_str(),
+          pyclass_name.c_str(),
           R"pbdoc(
 This class implements a deterministic version of the Schreier-Sims algorithm
 acting on a relatively small number of points (< 1000).
@@ -169,8 +170,8 @@ Test membership of an element.
 
 :rtype: bool
 )pbdoc");
-      thing.def("contains_no_run",
-                &SchreierSims_::contains_no_run,
+      thing.def("currently_contains",
+                &SchreierSims_::currently_contains,
                 py::arg("x"),
                 R"pbdoc(
 Test membership of an element without running.
@@ -384,6 +385,18 @@ Returns the size of the group represented by this.
 
 :rtype: int
 )pbdoc");
+      thing.def("current_size",
+                &SchreierSims_::current_size,
+                R"pbdoc(
+Returns the size of the group represented by this.
+Returns the size of the group represented by this.
+
+:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+
+:returns:  the size, a value of ``int``.
+
+:rtype: int
+)pbdoc");
       thing.def("strong_generator",
                 &SchreierSims_::strong_generator,
                 py::arg("depth"),
@@ -463,7 +476,8 @@ This function finds the intersection of two permutation groups. It modifies the 
 
   void init_schreier_sims(py::module& m) {
     // One call to bind is required per list of types
-    bind_schreier_sims<255>(m, "SchreierSims");
+    bind_schreier_sims<255, uint8_t, Perm<0, uint8_t>>(m, "Perm1");
+    bind_schreier_sims<511, uint16_t, Perm<0, uint16_t>>(m, "Perm2");
   }
 
 }  // namespace libsemigroups

--- a/src/schreier-sims.cpp
+++ b/src/schreier-sims.cpp
@@ -50,10 +50,9 @@ namespace libsemigroups {
 
       std::string pyclass_name = std::string("SchreierSims") + name;
 
-      py::class_<SchreierSims_, std::unique_ptr<SchreierSims_>> thing(
-          m,
-          pyclass_name.c_str(),
-          R"pbdoc(
+      py::class_<SchreierSims_> thing(m,
+                                      pyclass_name.c_str(),
+                                      R"pbdoc(
 This class implements a deterministic version of the Schreier-Sims algorithm
 acting on a relatively small number of points (< 1000).
 
@@ -89,8 +88,41 @@ the list *gens*.
       thing.def(py::init<SchreierSims_ const&>(), R"pbdoc(
       Default copy constructor.
 )pbdoc");
-      thing.def("__copy__",
+      thing.def(
+          "__copy__",
+          [](SchreierSims_ const& S) { return SchreierSims_(S); },
+          py::return_value_policy::automatic);
+      thing.def(
+          "copy1",
+          [](SchreierSims_ const& S) { return SchreierSims_(S); },
+          py::return_value_policy::automatic);
+      thing.def(
+          "copy2",
+          [](SchreierSims_ const& S) { return SchreierSims_(S); },
+          py::return_value_policy::automatic_reference);
+      thing.def(
+          "copy3",
+          [](SchreierSims_ const& S) { return SchreierSims_(S); },
+          py::return_value_policy::copy);
+      thing.def(
+          "copy4",
+          [](SchreierSims_ const& S) { return SchreierSims_(S); },
+          py::return_value_policy::move);
+      thing.def(
+          "copy5",
+          [](SchreierSims_ const& S) { return SchreierSims_(S); },
+          py::return_value_policy::reference);
+      thing.def(
+          "copy6",
+          [](SchreierSims_ const& S) { return SchreierSims_(S); },
+          py::return_value_policy::reference_internal);
+      thing.def(
+          "copy7",
+          [](SchreierSims_ const& S) { return SchreierSims_(S); },
+          py::return_value_policy::take_ownership);
+      thing.def("copy",
                 [](SchreierSims_ const& S) { return SchreierSims_(S); });
+      thing.def("kill", [](SchreierSims_ const& S) { S.~SchreierSims(); });
       thing.def("add_base_point",
                 &SchreierSims_::add_base_point,
                 py::arg("pt"),

--- a/src/schreier-sims.cpp
+++ b/src/schreier-sims.cpp
@@ -1,0 +1,468 @@
+
+//
+// libsemigroups_pybind11
+// Copyright (C) 2024 Joseph Edwards
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// TODO(0) Check types
+
+// C std headers....
+// TODO complete or delete
+
+// C++ stl headers....
+#include <memory>  // for allocator, make_unique, unique_ptr
+
+// libsemigroups headers
+#include <libsemigroups/libsemigroups.hpp>
+#include <libsemigroups/schreier-sims.hpp>
+
+// pybind11....
+#include <pybind11/pybind11.h>
+// #include <pybind11/chrono.h>
+// #include <pybind11/functional.h>
+// #include <pybind11/stl.h>
+// TODO uncomment/delete
+
+// libsemigroups_pybind11....
+#include "main.hpp"  // for init_schreier_sims
+
+namespace py = pybind11;
+
+namespace libsemigroups {
+
+  namespace {
+    template <size_t N>
+    void bind_schreier_sims(py::module& m, std::string const& name) {
+      using SchreierSims_ = SchreierSims<N>;
+
+      // TODO std::unique_ptr
+      py::class_<SchreierSims_> thing(m,
+                                      name.c_str(),
+                                      R"pbdoc(
+This class implements a deterministic version of the Schreier-Sims algorithm
+acting on a relatively small number of points (< 1000).
+
+:example: 
+
+.. doctest:: python
+
+    >>> from libsemigroups_pybind11 import SchreierSims, Perm
+    >>> SchreierSims S
+    >>> S.add_generator(Perm([1,  0,  2,  3,  4]))
+    >>> S.add_generator(Perm([1,  2,  3,  4,  0]))
+    >>> S.size()
+    120
+)pbdoc");
+      thing.def("__repr__", [](SchreierSims_ const& S) {
+        return to_human_readable_repr(S);
+      });
+      thing.def(py::init<>(), R"pbdoc(
+Default constructor.
+
+Construct a :any:`SchreierSims` object representing the trivial group.
+
+:complexity: Constant.
+)pbdoc");
+
+      thing.def(py::init<SchreierSims_ const&>(), R"pbdoc(
+      Default copy constructor.
+)pbdoc");
+      thing.def("__copy__",
+                [](SchreierSims_ const& S) { return SchreierSims_(S); });
+      thing.def("add_base_point",
+                &SchreierSims_::add_base_point,
+                py::arg("pt"),
+                R"pbdoc(
+Add a base point to the stabiliser chain.
+
+:param pt: the base point to add.
+:type pt: point_type
+Add a base point to the stabiliser chain.
+
+:raises LibsemigroupsError:  if ``pt`` is out of range.
+
+:raises LibsemigroupsError:  if :any:`finished()` returns ``True``.
+
+:raises LibsemigroupsError:  if ``pt`` is already a base point.
+
+:complexity: Linear in the current number of base points.)pbdoc");
+      thing.def("add_generator",
+                &SchreierSims_::add_generator,
+                py::arg("x"),
+                R"pbdoc(
+Add a generator.
+
+:param x: a const reference to the generator to add.
+:type x: const_element_reference
+This functions adds the argument ``x`` as a new generator if and only if ``x`` is not already an element of the group represented by the Schreier-Sims object.
+
+:raises LibsemigroupsError:  if the degree of ``x`` is not equal to the first template parameter ``N`` , or if ``self`` already contains the maximum number of elements.
+
+:complexity: Constant
+
+
+:returns:  ``True`` if ``x`` is added as a generator and ``False`` if it is not.
+
+:rtype: bool
+)pbdoc");
+      thing.def("base",
+                &SchreierSims_::base,
+                py::arg("index"),
+                R"pbdoc(
+Get a base point.
+
+:param index: the index of the base point.
+:type index: index_type
+Get a base point, having checked ``index`` if not out of range.
+
+:raises LibsemigroupsError:  if ``index`` is out of range.
+
+:complexity: Constant.
+
+
+:returns:  the base point with index ``index``.
+
+:rtype: point_type
+)pbdoc");
+      thing.def("base_size",
+                &SchreierSims_::base_size,
+                R"pbdoc(
+Get the size of the current base.
+Get the size of the current base.
+
+:exceptions: This function is ``noexcept`` and is guaranteed never to throw.
+
+:complexity: Constant.
+
+:returns: A ``int``.
+
+:rtype: int
+)pbdoc");
+      thing.def("contains",
+                &SchreierSims_::contains,
+                py::arg("x"),
+                R"pbdoc(
+Test membership of an element.
+
+:param x: a const reference to the possible element.
+:type x: const_element_reference
+Test membership of an element.
+
+:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+
+
+:returns: A ``bool``.
+
+:rtype: bool
+)pbdoc");
+      thing.def("contains_no_run",
+                &SchreierSims_::contains_no_run,
+                py::arg("x"),
+                R"pbdoc(
+Test membership of an element without running.
+
+:param x: a const reference to the possible element.
+:type x: const_element_reference
+Test membership of an element without running.
+
+:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+
+
+:returns: A ``bool``.
+
+:rtype: bool
+)pbdoc");
+      thing.def("empty",
+                &SchreierSims_::empty,
+                R"pbdoc(
+Check if any generators have been added so far.
+Check if any generators have been added so far.
+
+:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+
+:complexity: Constant.
+
+:returns:  ``True`` if ``number_of_generators() == 0`` and ``False`` otherwise.
+
+:rtype: bool
+)pbdoc");
+      thing.def("finished",
+                &SchreierSims_::finished,
+                R"pbdoc(
+Check if the stabiliser chain is fully enumerated.
+Check if the stabiliser chain is fully enumerated.
+
+:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+
+:complexity: Constant.
+
+:returns:  ``True`` if the stabiliser chain is fully enumerated and ``False`` otherwise.
+
+:rtype: bool
+)pbdoc");
+      thing.def("generator",
+                &SchreierSims_::generator,
+                py::arg("index"),
+                R"pbdoc(
+Get a generator.
+
+:param index: the index of the generator we want.
+:type index: index_type
+Get a generator with a given index, having checked that the index is in bounds.
+
+:raises LibsemigroupsError:  if the ``index`` is out of bounds.
+
+:complexity: Constant.
+
+
+:returns: A const reference to the generator of ``self`` with index ``index``.
+
+:rtype: const_element_reference
+)pbdoc");
+      thing.def("init",
+                &SchreierSims_::init,
+                R"pbdoc(
+Reset to the trivial group.
+Removes all generators, and orbits, and resets ``self`` so that it represents the trivial group, as if ``self`` had been newly constructed.
+
+:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+
+:complexity:  :math:`O(N ^ 2)` where ``N`` is the first template parameter.)pbdoc");
+      thing.def("inverse_transversal_element",
+                &SchreierSims_::inverse_transversal_element,
+                py::arg("depth"),
+                py::arg("pt"),
+                R"pbdoc(
+Get an inverse of a transversal element.
+
+:param depth: the depth. 
+:type depth: index_type
+
+:param pt: the point to map to the base point under the inverse_transversal_element.
+:type pt: point_type
+Get an inverse of a transversal element.
+
+:raises LibsemigroupsError:  if the ``depth`` is out of bounds.
+
+:raises LibsemigroupsError:  if ``pt`` is not in the orbit of the basepoint.
+
+:complexity: Constant.
+
+
+:returns: A const reference to the inverse_transversal_element element of ``self`` at depth ``depth`` moving the corresponding point ``pt`` to the basepoint.
+
+:rtype: const_element_reference
+)pbdoc");
+      thing.def("number_of_generators",
+                &SchreierSims_::number_of_generators,
+                R"pbdoc(
+The number of generators.
+Return the number of generators.
+
+:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+
+:complexity: Constant.
+
+:returns: The number of generators, a value of ``int``.
+
+:rtype: int
+)pbdoc");
+      thing.def("number_of_strong_generators",
+                &SchreierSims_::number_of_strong_generators,
+                py::arg("depth"),
+                R"pbdoc(
+The number of strong generators at a given depth.
+
+:param depth: the depth.
+:type depth: index_type
+Return the number of strong generators at a given depth.
+
+:raises LibsemigroupsError:  if the ``depth`` is out of bounds.
+
+:complexity: Constant.
+
+
+:returns: The number of strong generators, a value of ``int`` , at depth ``depth`` of the stabiliser chain.
+
+:rtype: int
+)pbdoc");
+      thing.def("one",
+                &SchreierSims_::one,
+                R"pbdoc(
+Returns a const reference to the identity.
+Returns a const reference to the identity.
+
+:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+
+:returns: A const reference to the identity element.
+
+:rtype: const_element_reference
+)pbdoc");
+      thing.def("orbit_lookup",
+                &SchreierSims_::orbit_lookup,
+                py::arg("depth"),
+                py::arg("pt"),
+                R"pbdoc(
+Check if a point is in the orbit of a basepoint.
+
+:param depth: the depth. 
+:type depth: index_type
+
+:param pt: the point.
+:type pt: point_type
+Check if a point is in the orbit of a basepoint.
+
+:raises LibsemigroupsError:  if the ``depth`` is out of bounds or if ``pt`` is out of bounds.
+
+:complexity: Constant.
+
+
+:returns: A boolean indicating if the point ``pt`` is in the orbit of the basepoint of ``self`` at depth ``depth``.
+
+:rtype: bool
+)pbdoc");
+      thing.def("run",
+                &SchreierSims_::run,
+                R"pbdoc(
+Run the Schreier-Sims algorithm.
+Run the Schreier-Sims algorithm.
+
+:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+
+:complexity:  :math:`O(N^2\log^3|G|+|T|N^2\log|G|)` time and :math:`O(N^2\log|G|+|T|N)` space, where ``N`` is the first template parameter, :math:`|G|` is the size of the group and :math:`|T|` is the number of generators of the group.)pbdoc");
+      thing.def("sift",
+                &SchreierSims_::sift,
+                py::arg("x"),
+                R"pbdoc(
+Sift an element through the stabiliser chain.
+
+:param x: a const reference to a group element.
+:type x: const_element_reference
+Sift an element through the stabiliser chain, having checked the degree of ``x`` is equal to the first template parameter ``N``.
+
+:raises LibsemigroupsError:  if the degree of ``x`` is not equal to the first template parameter ``N``.
+
+
+:returns: A value of type :any:`element_type`.
+
+:rtype: const_element_reference
+)pbdoc");
+      thing.def("sift_inplace",
+                &SchreierSims_::sift_inplace,
+                py::arg("x"),
+                R"pbdoc(
+Sift an element through the stabiliser chain in-place.
+
+:param x: a const reference to a group element.
+:type x: element_reference
+Sift an element through the stabiliser chain in-place, having checked the degree of ``x`` is equal to the first template parameter ``N``.
+
+:raises LibsemigroupsError:  if the degree of ``x`` is not equal to the first template parameter ``N``.)pbdoc");
+      thing.def("size",
+                &SchreierSims_::size,
+                R"pbdoc(
+Returns the size of the group represented by this.
+Returns the size of the group represented by this.
+
+:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+
+:returns:  the size, a value of ``int``.
+
+:rtype: int
+)pbdoc");
+      thing.def("strong_generator",
+                &SchreierSims_::strong_generator,
+                py::arg("depth"),
+                py::arg("index"),
+                R"pbdoc(
+Get a strong generator.
+
+:param depth: the depth. 
+:type depth: index_type
+
+:param index: the index of the generator we want.
+:type index: index_type
+Get a strong generator.
+
+:raises LibsemigroupsError:  if the ``depth`` is out of bounds.
+
+:raises LibsemigroupsError:  if the ``index`` is out of bounds.
+
+:complexity: Constant.
+
+
+:returns: A const reference to the strong generator of ``self`` at depth ``depth`` and with index ``index``.
+
+:rtype: const_element_reference
+)pbdoc");
+      thing.def("transversal_element",
+                &SchreierSims_::transversal_element,
+                py::arg("depth"),
+                py::arg("pt"),
+                R"pbdoc(
+Get a transversal element.
+
+:param depth: the depth. 
+:type depth: index_type
+
+:param pt: the image of the base point under the traversal.
+:type pt: point_type
+Get a transversal element.
+
+:raises LibsemigroupsError:  if the ``depth`` is out of bounds.
+
+:raises LibsemigroupsError:  if ``pt`` is not in the orbit of the basepoint.
+
+:complexity: Constant.
+
+
+:returns: A const reference to the transversal element of ``self`` at depth ``depth`` moving the corresponding basepoint to the point ``pt``.
+
+:rtype: const_element_reference
+)pbdoc");
+
+      m.def(
+          "intersection",
+          [](SchreierSims_& T, SchreierSims_& S1, SchreierSims_& S2) {
+            return schreier_sims::intersection(T, S1, S2);
+          },
+          py::arg("T"),
+          py::arg("S1"),
+          py::arg("S2"),
+          R"pbdoc(
+Find the intersection of two permutation groups.
+
+:param T: an empty Schreier-Sims object that will hold the result. 
+:type T: SchreierSims
+
+:param S1: the first semigroup of the intersection. 
+:type S1: SchreierSims
+
+:param S2: the second group of the intersection.
+:type S2: SchreierSims
+This function finds the intersection of two permutation groups. It modifies the first parameter ``T`` to be the Schreier-Sims object corresponding to the intersection of ``S1`` and ``S2``.
+
+:raises LibsemigroupsError:  if ``T`` is not empty.)pbdoc");
+
+    }  // bind_schreier_sims
+  }    // namespace
+
+  void init_schreier_sims(py::module& m) {
+    // One call to bind is required per list of types
+    bind_schreier_sims<256>(m, "SchreierSims");
+  }
+
+}  // namespace libsemigroups

--- a/src/schreier-sims.cpp
+++ b/src/schreier-sims.cpp
@@ -482,7 +482,6 @@ corresponding to the intersection of *S1* and *S2*.
 
 :raises LibsemigroupsError:  if *T* is not empty.
 )pbdoc");
-
     }  // bind_schreier_sims
   }    // namespace
 

--- a/src/schreier-sims.cpp
+++ b/src/schreier-sims.cpp
@@ -62,9 +62,9 @@ acting on a relatively small number of points (< 1000).
 .. doctest:: python
 
     >>> from libsemigroups_pybind11 import SchreierSims, Perm
-    >>> SchreierSims S
-    >>> S.add_generator(Perm([1,  0,  2,  3,  4]))
-    >>> S.add_generator(Perm([1,  2,  3,  4,  0]))
+    >>> p1 = Perm([1, 0, 2, 3, 4] + list(range(5, 255)))
+    >>> p2 = Perm([1, 2, 3, 4, 0] + list(range(5, 255)))
+    >>> S = SchreierSims(p1, p2)
     >>> S.size()
     120
 )pbdoc");
@@ -72,11 +72,18 @@ acting on a relatively small number of points (< 1000).
         return to_human_readable_repr(S);
       });
       thing.def(py::init<>(), R"pbdoc(
-Default constructor.
+:sig=(self: SchreierSimsPerm1, gens: List[Element]) -> None:
+Construct from a list of generators.
 
-Construct a :any:`SchreierSims` object representing the trivial group.
+This function constructs a :any:`SchreierSimsPerm1` instance with generators in
+the list *gens*.
 
-:complexity: Constant.
+:param gens: the list of generators.
+:type gens: List[Element]
+
+:raises LibsemigroupsError: if the generators do not have degree equal to 
+      :math:`255` or :math:`511`, or the number of generators exceeds the
+      maximum capacity.
 )pbdoc");
 
       thing.def(py::init<SchreierSims_ const&>(), R"pbdoc(
@@ -91,14 +98,13 @@ Construct a :any:`SchreierSims` object representing the trivial group.
 Add a base point to the stabiliser chain.
 
 :param pt: the base point to add.
-:type pt: point_type
-Add a base point to the stabiliser chain.
+:type pt: int
 
-:raises LibsemigroupsError:  if ``pt`` is out of range.
+:raises LibsemigroupsError:  if *pt* is out of range.
 
-:raises LibsemigroupsError:  if :any:`finished()` returns ``True``.
+:raises LibsemigroupsError:  if *pt* is already a base point.
 
-:raises LibsemigroupsError:  if ``pt`` is already a base point.
+:raises LibsemigroupsError:  if :any:`SchreierSimsPerm1.finished()` returns ``True``.
 
 :complexity: Linear in the current number of base points.)pbdoc");
       thing.def("add_generator",
@@ -107,18 +113,20 @@ Add a base point to the stabiliser chain.
                 R"pbdoc(
 Add a generator.
 
-:param x: a const reference to the generator to add.
-:type x: const_element_reference
-This functions adds the argument ``x`` as a new generator if and only if ``x`` is not already an element of the group represented by the Schreier-Sims object.
+This functions adds the argument *x* as a new generator if and only if *x* is
+not already an element of the group represented by the Schreier-Sims object.
 
-:raises LibsemigroupsError:  if the degree of ``x`` is not equal to the first template parameter ``N`` , or if ``self`` already contains the maximum number of elements.
+:param x: the generator to add.
+:type x: Element
+
+:returns:  ``True`` if *x* is added as a generator and ``False`` if it is not.
+:rtype: bool
+
+:raises LibsemigroupsError:  if the degree of *x* is not equal to :math:`255` 
+      or :math:`511`, or if ``self`` already contains the maximum number of 
+      elements.
 
 :complexity: Constant
-
-
-:returns:  ``True`` if ``x`` is added as a generator and ``False`` if it is not.
-
-:rtype: bool
 )pbdoc");
       thing.def("base",
                 &SchreierSims_::base,
@@ -126,32 +134,28 @@ This functions adds the argument ``x`` as a new generator if and only if ``x`` i
                 R"pbdoc(
 Get a base point.
 
-:param index: the index of the base point.
-:type index: index_type
-Get a base point, having checked ``index`` if not out of range.
+This function gets the base point with a given index.
 
-:raises LibsemigroupsError:  if ``index`` is out of range.
+:param index: the index of the base point.
+:type index: int
+
+:returns: The base point with index *index*.
+:rtype: int
+
+:raises LibsemigroupsError:  if *index* is out of range.
 
 :complexity: Constant.
 
-
-:returns:  the base point with index ``index``.
-
-:rtype: point_type
 )pbdoc");
       thing.def("base_size",
                 &SchreierSims_::base_size,
                 R"pbdoc(
 Get the size of the current base.
-Get the size of the current base.
 
-:exceptions: This function is ``noexcept`` and is guaranteed never to throw.
+:returns: The base size.
+:rtype: int
 
 :complexity: Constant.
-
-:returns: A ``int``.
-
-:rtype: int
 )pbdoc");
       thing.def("contains",
                 &SchreierSims_::contains,
@@ -159,15 +163,11 @@ Get the size of the current base.
                 R"pbdoc(
 Test membership of an element.
 
-:param x: a const reference to the possible element.
-:type x: const_element_reference
-Test membership of an element.
+:param x: the possible element.
+:type x: Element
 
-:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
-
-
-:returns: A ``bool``.
-
+:returns: ``True`` if *element* is a contained in the :any:`SchreierSimsPerm1`
+      instance, and ``False`` otherwise.
 :rtype: bool
 )pbdoc");
       thing.def("currently_contains",
@@ -176,44 +176,34 @@ Test membership of an element.
                 R"pbdoc(
 Test membership of an element without running.
 
-:param x: a const reference to the possible element.
-:type x: const_element_reference
-Test membership of an element without running.
+This function tests the membership of an element without running the algorithm.
 
-:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+:param x: the possible element.
+:type x: Element
 
-
-:returns: A ``bool``.
-
+:returns: ``True`` if *element* is a contained in the :any:`SchreierSimsPerm1`
+      instance, and ``False`` otherwise.
 :rtype: bool
 )pbdoc");
       thing.def("empty",
                 &SchreierSims_::empty,
                 R"pbdoc(
 Check if any generators have been added so far.
-Check if any generators have been added so far.
-
-:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
-
-:complexity: Constant.
 
 :returns:  ``True`` if ``number_of_generators() == 0`` and ``False`` otherwise.
-
 :rtype: bool
+
+:complexity: Constant.
 )pbdoc");
       thing.def("finished",
                 &SchreierSims_::finished,
                 R"pbdoc(
 Check if the stabiliser chain is fully enumerated.
-Check if the stabiliser chain is fully enumerated.
-
-:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
-
-:complexity: Constant.
 
 :returns:  ``True`` if the stabiliser chain is fully enumerated and ``False`` otherwise.
-
 :rtype: bool
+
+:complexity: Constant.
 )pbdoc");
       thing.def("generator",
                 &SchreierSims_::generator,
@@ -221,28 +211,28 @@ Check if the stabiliser chain is fully enumerated.
                 R"pbdoc(
 Get a generator.
 
-:param index: the index of the generator we want.
-:type index: index_type
-Get a generator with a given index, having checked that the index is in bounds.
+This function returns the generator with a given index.
 
-:raises LibsemigroupsError:  if the ``index`` is out of bounds.
+:param index: the index of the generator to return.
+:type index: int
+
+:returns: The generator with index *index*.
+:rtype: Element
+
+:raises LibsemigroupsError:  if the *index* is out of bounds.
 
 :complexity: Constant.
-
-
-:returns: A const reference to the generator of ``self`` with index ``index``.
-
-:rtype: const_element_reference
 )pbdoc");
       thing.def("init",
                 &SchreierSims_::init,
                 R"pbdoc(
 Reset to the trivial group.
-Removes all generators, and orbits, and resets ``self`` so that it represents the trivial group, as if ``self`` had been newly constructed.
 
-:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+This function removes all generators, and orbits, and resets ``self`` so that it
+represents the trivial group, as if ``self`` had been newly constructed.
 
-:complexity:  :math:`O(N ^ 2)` where ``N`` is the first template parameter.)pbdoc");
+:complexity: Constant.
+)pbdoc");
       thing.def("inverse_transversal_element",
                 &SchreierSims_::inverse_transversal_element,
                 py::arg("depth"),
@@ -250,37 +240,36 @@ Removes all generators, and orbits, and resets ``self`` so that it represents th
                 R"pbdoc(
 Get an inverse of a transversal element.
 
+This function returns the transversal element at depth *depth* which sends *pt*
+to the basepoint.
+
 :param depth: the depth. 
-:type depth: index_type
+:type depth: int
 
-:param pt: the point to map to the base point under the inverse_transversal_element.
-:type pt: point_type
-Get an inverse of a transversal element.
+:param pt: the point to map to the base point under the inverse transversal
+      element.
+:type pt: int
 
-:raises LibsemigroupsError:  if the ``depth`` is out of bounds.
+:returns: the inverse transversal element.
+:rtype: Element
 
-:raises LibsemigroupsError:  if ``pt`` is not in the orbit of the basepoint.
+:raises LibsemigroupsError:  if the *depth* is out of bounds.
+
+:raises LibsemigroupsError:  if *pt* is not in the orbit of the basepoint.
 
 :complexity: Constant.
-
-
-:returns: A const reference to the inverse_transversal_element element of ``self`` at depth ``depth`` moving the corresponding point ``pt`` to the basepoint.
-
-:rtype: const_element_reference
 )pbdoc");
       thing.def("number_of_generators",
                 &SchreierSims_::number_of_generators,
                 R"pbdoc(
 The number of generators.
-Return the number of generators.
 
-:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
+This function returns the number of generators.
+
+:returns: The number of generators.
+:rtype: int
 
 :complexity: Constant.
-
-:returns: The number of generators, a value of ``int``.
-
-:rtype: int
 )pbdoc");
       thing.def("number_of_strong_generators",
                 &SchreierSims_::number_of_strong_generators,
@@ -288,30 +277,26 @@ Return the number of generators.
                 R"pbdoc(
 The number of strong generators at a given depth.
 
-:param depth: the depth.
-:type depth: index_type
-Return the number of strong generators at a given depth.
+This function returns the number of strong generators of the stabiliser chain at
+a given depth.
 
-:raises LibsemigroupsError:  if the ``depth`` is out of bounds.
+:param depth: the depth.
+:type depth: int
+
+:returns: The number of strong generators.
+:rtype: int
+
+:raises LibsemigroupsError:  if the *depth* is out of bounds.
 
 :complexity: Constant.
-
-
-:returns: The number of strong generators, a value of ``int`` , at depth ``depth`` of the stabiliser chain.
-
-:rtype: int
 )pbdoc");
       thing.def("one",
                 &SchreierSims_::one,
                 R"pbdoc(
 Returns a const reference to the identity.
-Returns a const reference to the identity.
 
-:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
-
-:returns: A const reference to the identity element.
-
-:rtype: const_element_reference
+:returns: The identity element.
+:rtype: Element
 )pbdoc");
       thing.def("orbit_lookup",
                 &SchreierSims_::orbit_lookup,
@@ -321,46 +306,45 @@ Returns a const reference to the identity.
 Check if a point is in the orbit of a basepoint.
 
 :param depth: the depth. 
-:type depth: index_type
+:type depth: int
 
 :param pt: the point.
-:type pt: point_type
-Check if a point is in the orbit of a basepoint.
+:type pt: int
 
-:raises LibsemigroupsError:  if the ``depth`` is out of bounds or if ``pt`` is out of bounds.
+:returns: ``True`` if the point *pt* is in the orbit of the basepoint of
+      ``self`` at depth *depth*, and ``False`` otherwise.
+:rtype: bool
+
+:raises LibsemigroupsError:  if the *depth*` is out of bounds or if *pt* is out
+      of bounds.
 
 :complexity: Constant.
-
-
-:returns: A boolean indicating if the point ``pt`` is in the orbit of the basepoint of ``self`` at depth ``depth``.
-
-:rtype: bool
 )pbdoc");
       thing.def("run",
                 &SchreierSims_::run,
                 R"pbdoc(
 Run the Schreier-Sims algorithm.
-Run the Schreier-Sims algorithm.
 
-:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
 
-:complexity:  :math:`O(N^2\log^3|G|+|T|N^2\log|G|)` time and :math:`O(N^2\log|G|+|T|N)` space, where ``N`` is the first template parameter, :math:`|G|` is the size of the group and :math:`|T|` is the number of generators of the group.)pbdoc");
+:complexity:  :math:`O(N^2\log^3|G|+|T|N^2\log|G|)` time and 
+      :math:`O(N^2\log|G|+|T|N)` space, where ``N`` is the degree of the
+      generators, :math:`|G|` is the size of the group and :math:`|T|` is the
+      number of generators of the group.
+)pbdoc");
       thing.def("sift",
                 &SchreierSims_::sift,
                 py::arg("x"),
                 R"pbdoc(
 Sift an element through the stabiliser chain.
 
-:param x: a const reference to a group element.
-:type x: const_element_reference
-Sift an element through the stabiliser chain, having checked the degree of ``x`` is equal to the first template parameter ``N``.
+:param x: A group element.
+:type x: Element
 
-:raises LibsemigroupsError:  if the degree of ``x`` is not equal to the first template parameter ``N``.
+:returns: A sifted element.
+:rtype: Element
 
-
-:returns: A value of type :any:`element_type`.
-
-:rtype: const_element_reference
+:raises LibsemigroupsError:  if the degree of *x* is not equal to the degree of
+      the generators.
 )pbdoc");
       thing.def("sift_inplace",
                 &SchreierSims_::sift_inplace,
@@ -368,33 +352,26 @@ Sift an element through the stabiliser chain, having checked the degree of ``x``
                 R"pbdoc(
 Sift an element through the stabiliser chain in-place.
 
-:param x: a const reference to a group element.
-:type x: element_reference
-Sift an element through the stabiliser chain in-place, having checked the degree of ``x`` is equal to the first template parameter ``N``.
+:param x: a group element.
+:type x: Element
 
-:raises LibsemigroupsError:  if the degree of ``x`` is not equal to the first template parameter ``N``.)pbdoc");
+:raises LibsemigroupsError:  if the degree of *x* is not equal to the degree of
+      the generators.
+)pbdoc");
       thing.def("size",
                 &SchreierSims_::size,
                 R"pbdoc(
-Returns the size of the group represented by this.
-Returns the size of the group represented by this.
+Returns the size of the group represented by ``self``.
 
-:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
-
-:returns:  the size, a value of ``int``.
-
+:returns:  the size of the group.
 :rtype: int
 )pbdoc");
       thing.def("current_size",
                 &SchreierSims_::current_size,
                 R"pbdoc(
-Returns the size of the group represented by this.
-Returns the size of the group represented by this.
+Returns the size of the group represented by this, without running the algorithm.
 
-:exceptions: This function guarantees not to throw a :any:`LibsemigroupsError`.
-
-:returns:  the size, a value of ``int``.
-
+:returns:  the size of the group.
 :rtype: int
 )pbdoc");
       thing.def("strong_generator",
@@ -404,48 +381,47 @@ Returns the size of the group represented by this.
                 R"pbdoc(
 Get a strong generator.
 
+This function returns the generator with a given depth and index.
+
 :param depth: the depth. 
-:type depth: index_type
+:type depth: int
 
-:param index: the index of the generator we want.
-:type index: index_type
-Get a strong generator.
+:param index: the index of the generator to return.
+:type index: int
 
-:raises LibsemigroupsError:  if the ``depth`` is out of bounds.
+:returns: The strong generator of at depth *depth* and with index *index*.
+:rtype: Element
 
-:raises LibsemigroupsError:  if the ``index`` is out of bounds.
+:raises LibsemigroupsError:  if the *depth* is out of bounds.
+
+:raises LibsemigroupsError:  if the *index* is out of bounds.
 
 :complexity: Constant.
-
-
-:returns: A const reference to the strong generator of ``self`` at depth ``depth`` and with index ``index``.
-
-:rtype: const_element_reference
 )pbdoc");
       thing.def("transversal_element",
                 &SchreierSims_::transversal_element,
                 py::arg("depth"),
                 py::arg("pt"),
                 R"pbdoc(
-Get a transversal element.
+Get an transversal element.
+
+This function returns the transversal element at depth *depth* which sends the
+corresponding basepoint to the point *pt*.
 
 :param depth: the depth. 
-:type depth: index_type
+:type depth: int
 
 :param pt: the image of the base point under the traversal.
-:type pt: point_type
-Get a transversal element.
+:type pt: int
 
-:raises LibsemigroupsError:  if the ``depth`` is out of bounds.
+:returns: The transversal element.
+:rtype: Element
 
-:raises LibsemigroupsError:  if ``pt`` is not in the orbit of the basepoint.
+:raises LibsemigroupsError:  if *depth* is out of bounds.
+
+:raises LibsemigroupsError:  if *pt* is not in the orbit of the basepoint.
 
 :complexity: Constant.
-
-
-:returns: A const reference to the transversal element of ``self`` at depth ``depth`` moving the corresponding basepoint to the point ``pt``.
-
-:rtype: const_element_reference
 )pbdoc");
 
       m.def(
@@ -459,17 +435,21 @@ Get a transversal element.
           R"pbdoc(
 Find the intersection of two permutation groups.
 
-:param T: an empty Schreier-Sims object that will hold the result. 
-:type T: SchreierSims
+This function finds the intersection of two permutation groups. 
+It modifies the first parameter *T* to be the :any:`SchreierSimsPerm1` object
+corresponding to the intersection of *S1* and *S2*.
 
-:param S1: the first semigroup of the intersection. 
-:type S1: SchreierSims
+:param T: an empty SchreierSims object that will hold the result. 
+:type T: SchreierSimsPerm1
+
+:param S1: the first group of the intersection. 
+:type S1: SchreierSimsPerm1
 
 :param S2: the second group of the intersection.
-:type S2: SchreierSims
-This function finds the intersection of two permutation groups. It modifies the first parameter ``T`` to be the Schreier-Sims object corresponding to the intersection of ``S1`` and ``S2``.
+:type S2: SchreierSimsPerm1
 
-:raises LibsemigroupsError:  if ``T`` is not empty.)pbdoc");
+:raises LibsemigroupsError:  if *T* is not empty.
+)pbdoc");
 
     }  // bind_schreier_sims
   }    // namespace

--- a/tests/test_schreier_sims.py
+++ b/tests/test_schreier_sims.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=no-name-in-module, missing-function-docstring
-# pylint: disable=missing-class-docstring, invalid-name, redefined-outer-name
+# pylint: disable=missing-class-docstring, missing-module-docstring
+# pylint: disable=invalid-name, redefined-outer-name
 
 # Copyright (c) 2024 Joseph Edwards
 #
@@ -15,8 +16,8 @@
 # * fix sift
 # * improve sift_inplace
 
-import pytest
 from copy import copy
+import pytest
 
 from libsemigroups_pybind11 import (
     Perm,

--- a/tests/test_schreier_sims.py
+++ b/tests/test_schreier_sims.py
@@ -39,7 +39,6 @@ def check_constructors(gens):
 
     assert S1 is not S2
     assert S1.number_of_generators() == S2.number_of_generators()
-    assert S1.number_of_strong_generators() == S2.number_of_strong_generators()
     assert S1.current_size() == S2.current_size()
     assert S1.finished() == S2.finished()
 

--- a/tests/test_schreier_sims.py
+++ b/tests/test_schreier_sims.py
@@ -10,11 +10,8 @@
 # The full license is in the file LICENSE, distributed with this software.
 
 # TODO(0):
-# * fix copy constructor
 # * test number_of_strong_generators
 # * test strong_generator
-# * fix sift
-# * improve sift_inplace
 
 from copy import copy
 import pytest
@@ -42,6 +39,7 @@ def check_constructors(gens):
 
     assert S1 is not S2
     assert S1.number_of_generators() == S2.number_of_generators()
+    assert S1.number_of_strong_generators() == S2.number_of_strong_generators()
     assert S1.current_size() == S2.current_size()
     assert S1.finished() == S2.finished()
 
@@ -337,19 +335,23 @@ def check_elements(n):
                     S.inverse_transversal_element(i, j)
 
 
-# def check_sift(gens):
-#     ReportGuard(False)
-#     S = SchreierSims(gens)
-#     for gen in gens:
-#         assert S.sift(gen) == S.one()
+def check_sift(gens):
+    ReportGuard(False)
+    S = SchreierSims(gens)
+    S.run()
+    for i, gen in enumerate(gens):
+        assert S.generator(i) == gen
+        assert list(S.sift(gen)) == list(S.one())
 
 
 def check_sift_inplace(gens):
     ReportGuard(False)
     S = SchreierSims(gens)
-    assert gens[0] != S.one()
-    S.sift_inplace(gens[0])
-    assert gens[0] == S.one()
+    one = S.one()
+    S.run()
+    for gen in gens:
+        S.sift_inplace(gen)
+    assert all(gen == one for gen in gens)
 
 
 def check_intersection(n):
@@ -496,11 +498,11 @@ def check_SchreierSims_001(n):
 @pytest.fixture
 def checks_with_generators():
     return (
-        # check_constructors,
+        check_constructors,
         check_generators,
         check_empty,
         check_finished,
-        # check_sift,
+        check_sift,
         check_sift_inplace,
     )
 
@@ -526,8 +528,26 @@ def test_SchreierSims_001(checks_with_generators):
 
 def test_SchreierSims_002(checks_with_generators):
     gens = [
+        Perm([0, 2, 4, 6, 7, 3, 8, 1, 5] + list(range(9, 255))),
+        Perm([0, 3, 5, 4, 8, 7, 2, 6, 1] + list(range(9, 255))),
+    ]
+    for check in checks_with_generators:
+        check(gens)
+
+
+def test_SchreierSims_003(checks_with_generators):
+    gens = [
         Perm([1, 0, 2, 3, 4] + list(range(5, 511))),
         Perm([1, 2, 3, 4, 0] + list(range(5, 511))),
+    ]
+    for check in checks_with_generators:
+        check(gens)
+
+
+def test_SchreierSims_004(checks_with_generators):
+    gens = [
+        Perm([0, 2, 4, 6, 7, 3, 8, 1, 5] + list(range(9, 511))),
+        Perm([0, 3, 5, 4, 8, 7, 2, 6, 1] + list(range(9, 511))),
     ]
     for check in checks_with_generators:
         check(gens)

--- a/tests/test_schreier_sims.py
+++ b/tests/test_schreier_sims.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=no-name-in-module, missing-function-docstring
+# pylint: disable=missing-class-docstring, invalid-name, redefined-outer-name
+
+# Copyright (c) 2024 Joseph Edwards
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+
+import pytest
+from copy import copy
+
+from libsemigroups_pybind11 import (
+    Perm,
+    LibsemigroupsError,
+    SchreierSims,
+    ReportGuard,
+)
+
+
+def check_constructors(gens):
+    ReportGuard(False)
+    # default constructor
+    with pytest.raises(ValueError):
+        SchreierSims()
+
+    S1 = SchreierSims(gens)
+
+    # copy constructor
+    S2 = copy(S1)
+
+    assert S1 is not S2
+    assert S1.number_of_generators() == S2.number_of_generators()
+    assert S1.current_size() == S2.current_size()
+    assert S1.finished() == S2.finished()
+
+
+def check_generators(gens):
+    ReportGuard(False)
+    S = SchreierSims(gens)
+    for i, gen in enumerate(gens):
+        assert S.generator(i) == gen
+
+    with pytest.raises(LibsemigroupsError):
+        S.generator(len(gens))
+
+    U = SchreierSims(gens[0])
+    for x in gens[1:]:
+        U.add_generator(x)
+    assert S.number_of_generators() == U.number_of_generators()
+    assert S.size() == U.size()
+
+
+@pytest.fixture
+def checks_for_SchreierSims():
+    return (
+        # check_constructors,
+        check_generators,
+    )
+
+
+# def test_SchreierSims_001(checks_for_generators):
+#     gens = [
+#         Perm([1, 0, 2, 3, 4] + list(range(5, 255))),
+#         Perm([1, 2, 3, 4, 0] + list(range(5, 255))),
+#     ]
+#     for check in checks_for_generators:
+#         check(gens)
+
+# def test_SchreierSims_002(checks_for_generators):
+#     gens = [
+#         Perm([1, 0, 2, 3, 4] + list(range(5, 511))),
+#         Perm([1, 2, 3, 4, 0] + list(range(5, 511))),
+#     ]
+#     for check in checks_for_generators:
+#         check(gens)
+
+
+def test_SchreierSims_002(checks_for_SchreierSims):
+    gens = [
+        Perm([1, 0, 2, 3, 4] + list(range(5, 255))),
+        Perm([1, 2, 3, 4, 0] + list(range(5, 255))),
+    ]
+    for check in checks_for_SchreierSims:
+        check(gens)


### PR DESCRIPTION
This PR adds the `SchreierSims` class and associated helpers in advance of the v1 release. Supersedes #109.

## TODO

- [x] Add the bindings to the `cpp` file;
- [x] Expose the functionality in `libsemigoups_pybind11`;
- [x] Add the the pages to the doc;
- [x] Wrap the class in a Python class (after #197 is merged);
- [x] Format the documentation and the signatures;
- [x] Add tests.