### PR TITLE
Minor doc fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools==75.6.0
 graphviz==0.20.3
 numpy==2.0.2
 packaging==24.2

--- a/src/aho-corasick.cpp
+++ b/src/aho-corasick.cpp
@@ -371,7 +371,7 @@ index *start*, and traversing using the letters in the word *w*.
 :param ac: object to traverse.
 :type ac: AhoCorasick
 
-:param start: TODO(0)
+:param start: the index of the node to first traverse from.
 :type start: int
 
 :param w: Word to traverse by

--- a/src/kambites.cpp
+++ b/src/kambites.cpp
@@ -188,11 +188,9 @@ contained in the congruence, but that this is not currently known.
              Presentation<OtherWord> const& p) { return self.init(knd, p); },
           py::arg("knd"),
           py::arg("p"),
-          // TODO(0) adding only-document-once here means that the other
-          // overload of init is suppressed also :(
-          // :only-document-once:
           R"pbdoc(
 :sig=(self: Kambites, knd: congruence_kind, p: Presentation) -> Kambites:
+:only-document-once:
 
 Re-initialize a :any:`Kambites` instance.
 
@@ -322,6 +320,8 @@ Copy a :any:`Kambites` object.
           "init",
           [](Kambites_& self) { return self.init(); },
           R"pbdoc(
+:sig=(self: Kambites) -> Kambites:
+:only-document-once:
 Re-initialize a :any:`Kambites` instance.
 
 This function puts a :any:`Kambites` instance back into the state that it would

--- a/src/kambites.cpp
+++ b/src/kambites.cpp
@@ -189,7 +189,7 @@ contained in the congruence, but that this is not currently known.
           py::arg("knd"),
           py::arg("p"),
           R"pbdoc(
-:sig=(self: Kambites, knd: congruence_kind, p: Presentation) -> Kambites:
+:sig=(self: Kambites, knd: congruence_kind, p: PresentationStrings) -> Kambites:
 :only-document-once:
 
 Re-initialize a :any:`Kambites` instance.

--- a/src/knuth-bendix.cpp
+++ b/src/knuth-bendix.cpp
@@ -318,7 +318,6 @@ instance.
           .def(py::init<congruence_kind, Presentation<std::string> const&>(),
                py::arg("knd"),
                py::arg("p"),
-               // TODO(0) this constructor's doc is duplicated, but including
                R"pbdoc(
 :sig=(knd: congruence_kind, p: PresentationStrings) -> None:
 :only-document-once:

--- a/src/knuth-bendix.cpp
+++ b/src/knuth-bendix.cpp
@@ -579,7 +579,7 @@ system is measured.
 :return: The overlap policy.
 :rtype: overlap
 
-.. seealso:: :py:class:`overlap`.
+.. seealso:: :any:`overlap`.
 )pbdoc")
           .def("overlap_policy",
                py::overload_cast<
@@ -600,7 +600,7 @@ two words in the system is measured.
 :return: ``self``.
 :rtype: KnuthBendixRewriteTrie
 
-.. seealso:: :py:class:`overlap`
+.. seealso:: :any:`overlap`.
 )pbdoc");
       //////////////////////////////////////////////////////////////////////////
       // Member functions for rules and rewriting
@@ -778,11 +778,15 @@ Run the Knuth-Bendix algorithm by considering all overlaps of a given length.
 
 This function runs the Knuth-Bendix algorithm on the rewriting system
 represented by a :any:`KnuthBendixRewriteTrie` instance by considering all overlaps of a
-given length :math:`n` (according to the :any:`libsemigroups_pybind11.overlap`) before those overlaps
+given length :math:`n` (according to the type of :any:`overlap`) before those overlaps
 of length :math:`n + 1`.
 
 :param kb: the :any:`KnuthBendixRewriteTrie` instance.
 :type kb: KnuthBendixRewriteTrie
+
+.. seealso:: :any:`KnuthBendixRewriteTrie.overlap_policy`
+
+
 )pbdoc");
       m.def(
           "knuth_bendix_is_reduced",

--- a/src/knuth-bendix.cpp
+++ b/src/knuth-bendix.cpp
@@ -307,6 +307,8 @@ two words :math:`AB` and :math:`BC`.
 
       kb.def(py::init<>(),
              R"pbdoc(
+:sig=() -> None:
+:only-document-once:
 Constructs a :any:`KnuthBendixRewriteTrie` instance with no
 rules, and the short-lex reduction ordering.
 
@@ -317,9 +319,9 @@ instance.
                py::arg("knd"),
                py::arg("p"),
                // TODO(0) this constructor's doc is duplicated, but including
-               // :only-document-once: suppresses the default constructors doc.
                R"pbdoc(
 :sig=(knd: congruence_kind, p: PresentationStrings) -> None:
+:only-document-once:
 
 Construct from :any:`congruence_kind` and :any:`PresentationStrings`.
 
@@ -337,7 +339,7 @@ presentation *p*.
           .def(py::init<congruence_kind, Presentation<word_type> const&>(),
                R"pbdoc(
 :sig=(knd: congruence_kind, p: PresentationStrings) -> None:
-TODO(0) remove this
+:only-document-once:
 )pbdoc")
           .def(
               "init",

--- a/src/knuth-bendix.cpp
+++ b/src/knuth-bendix.cpp
@@ -364,7 +364,7 @@ constructed.
               py::arg("knd"),
               py::arg("p"),
               R"pbdoc(
-:sig=(self: KnuthBendixRewriteTrie, knd: congruence_kind, p: Presentation) -> KnuthBendixRewriteTrie:
+:sig=(self: KnuthBendixRewriteTrie, knd: congruence_kind, p: PresentationStrings) -> KnuthBendixRewriteTrie:
 :only-document-once:
 
 Re-initialize a KnuthBendix instance.
@@ -377,7 +377,7 @@ that it would have been in if it had just been newly constructed from *knd* and
 :type knd: congruence_kind
 
 :param p: the presentation.
-:type p: Presentation
+:type p: PresentationStrings
 
 :returns: ``self``.
 :rtype: KnuthBendix
@@ -394,7 +394,7 @@ that it would have been in if it had just been newly constructed from *knd* and
               py::arg("knd"),
               py::arg("p"),
               R"pbdoc(
-:sig=(self: KnuthBendixRewriteTrie, knd: congruence_kind, p: Presentation) -> KnuthBendixRewriteTrie:
+:sig=(self: KnuthBendixRewriteTrie, knd: congruence_kind, p: PresentationStrings) -> KnuthBendixRewriteTrie:
 :only-document-once:
 )pbdoc")
           .def(

--- a/src/obvinf.cpp
+++ b/src/obvinf.cpp
@@ -42,10 +42,10 @@ namespace libsemigroups {
 :sig=(p: PresentationStrings) -> bool:
 
 Function for checking if the finitely presented semigroup or monoid
-defined by a :any:`Presentation` object is obviously infinite or not.
+defined by a :any:`PresentationStrings` object is obviously infinite or not.
 
 This function returns ``True`` if the finitely presented semigroup or
-monoid defined by the :any:`Presentation` object *p* is obviously infinite.
+monoid defined by the :any:`PresentationStrings` object *p* is obviously infinite.
 
 :param p: the presentation.
 :type p: Presentation
@@ -73,10 +73,10 @@ monoid defined by the :any:`Presentation` object *p* is obviously infinite.
 :only-document-once:
 
 Function for checking if the finitely presented semigroup or monoid
-defined by a :any:`Presentation` object is obviously infinite or not.
+defined by a :any:`PresentationStrings` object is obviously infinite or not.
 
 This function returns ``True`` if the finitely presented semigroup or
-monoid defined by the :any:`Presentation` object *p* is obviously infinite.
+monoid defined by the :any:`PresentationStrings` object *p* is obviously infinite.
 
 :param p: the presentation.
 :type p: Presentation

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -1235,7 +1235,7 @@ Construct an InversePresentationStrings from a Presentation reference.
 
 Construct an :any:`InversePresentationStrings` , initially with empty inverses, from a :any:`PresentationStrings`.
 
-:param p: the Presentation to construct from.
+:param p: the presentation to construct from.
 :type p: PresentationStrings
 )pbdoc");
       thing.def(py::init<>(), R"pbdoc(

--- a/src/schreier-sims.cpp
+++ b/src/schreier-sims.cpp
@@ -19,9 +19,6 @@
 
 // TODO(0) Check types
 
-// C std headers....
-// TODO complete or delete
-
 // C++ stl headers....
 #include <memory>  // for allocator, make_unique, unique_ptr
 
@@ -31,10 +28,6 @@
 
 // pybind11....
 #include <pybind11/pybind11.h>
-// #include <pybind11/chrono.h>
-// #include <pybind11/functional.h>
-// #include <pybind11/stl.h>
-// TODO uncomment/delete
 
 // libsemigroups_pybind11....
 #include "main.hpp"  // for init_schreier_sims

--- a/src/todd-coxeter.cpp
+++ b/src/todd-coxeter.cpp
@@ -246,6 +246,8 @@ definitions in the stack exceeds the value :any:`ToddCoxeter.def_max`.
 
     thing.def(py::init<>(),
               R"pbdoc(
+:sig=(self: ToddCoxeter) -> None:
+:only-document-once:
 Default constructor. This function default constructs an uninitialised
 :any:`ToddCoxeter` instance.
 )pbdoc");
@@ -285,7 +287,8 @@ Copy a :any:`ToddCoxeter` object.
               py::arg("knd"),
               py::arg("p"),
               R"pbdoc(
-:sig=(self: ToddCoxeter, knd: congruence_kind, p: Presentation) -> None:
+:sig=(self: ToddCoxeter, knd: congruence_kind, p: PresentationStrings) -> None:
+:only-document-once:
 
 Construct from :any:`congruence_kind` and :any:`PresentationStrings`.
 
@@ -309,8 +312,8 @@ converted presentation can be recovered using :any:`ToddCoxeter.presentation`.
               py::arg("knd"),
               py::arg("p"),
               R"pbdoc(
-:sig=(self: ToddCoxeter, knd: congruence_kind, p: Presentation) -> None:
-TODO(0) make this disappear
+:sig=(self: ToddCoxeter, knd: congruence_kind, p: PresentationStrings) -> None:
+:only-document-once:
 )pbdoc");
 
     thing.def(py::init<congruence_kind, ToddCoxeter&>(),
@@ -318,6 +321,7 @@ TODO(0) make this disappear
               py::arg("tc"),
               R"pbdoc(
 :sig=(self: ToddCoxeter, knd: congruence_kind, tc: ToddCoxeter) -> None:
+:only-document-once:
 
 Construct from :any:`congruence_kind` and :any:`ToddCoxeter`.
 
@@ -343,6 +347,8 @@ the word graph represented by *tc*.
               py::arg("wg"),
               R"pbdoc(
 :sig=(self: ToddCoxeter, knd: congruence_kind, wg: WordGraph) -> None:
+:only-document-once:
+
 Construct from :any:`congruence_kind` and :any:`WordGraph`.
 
 This function constructs a :any:`ToddCoxeter` instance representing a

--- a/src/todd-coxeter.cpp
+++ b/src/todd-coxeter.cpp
@@ -255,6 +255,8 @@ Default constructor. This function default constructs an uninitialised
         "init",
         [](ToddCoxeter& self) { return self.init(); },
         R"pbdoc(
+:sig=(self: ToddCoxeter) -> ToddCoxeter:
+:only-document-once:
 Re-initialize a ToddCoxeter instance. This function puts a
 :any:`ToddCoxeter` instance back into the state that it would have been
 in if it had just been newly default constructed.
@@ -374,7 +376,8 @@ semigroup.
         py::arg("knd"),
         py::arg("p"),
         R"pbdoc(
-:sig=(self: ToddCoxeter, knd: congruence_kind, p: Presentation) -> ToddCoxeter:
+:sig=(self: ToddCoxeter, knd: congruence_kind, p: PresentationStrings) -> ToddCoxeter:
+:only-document-once:
 
 Re-initialize a ToddCoxeter instance.
 
@@ -400,8 +403,8 @@ had been newly constructed from *knd* and *p*.
         py::arg("knd"),
         py::arg("p"),
         R"pbdoc(
-:sig=(self: ToddCoxeter, knd: congruence_kind, p: Presentation) -> ToddCoxeter:
-TODO(0) make this disappear
+:sig=(self: ToddCoxeter, knd: congruence_kind, p: PresentationStrings) -> ToddCoxeter:
+:only-document-once:
 )pbdoc");
     thing.def(
         "init",
@@ -412,6 +415,7 @@ TODO(0) make this disappear
         py::arg("tc"),
         R"pbdoc(
 :sig=(self: ToddCoxeter, knd: congruence_kind, tc: ToddCoxeter) -> ToddCoxeter:
+:only-document-once:
 
 Re-initialize a ToddCoxeter instance.
 
@@ -444,6 +448,7 @@ that it would have been in if it had just been newly constructed from
         py::arg("wg"),
         R"pbdoc(
 :sig=(self: ToddCoxeter, knd: congruence_kind, wg: WordGraph) -> ToddCoxeter:
+:only-document-once:
 
 Re-initialize a ToddCoxeter instance.
 

--- a/src/words.cpp
+++ b/src/words.cpp
@@ -395,7 +395,6 @@ Sets the number of letters in a :any:`WordRange` object to *n*.
 :returns: A reference to ``self``.
 :rtype: WordRange
 )pbdoc");
-    // TODO(now) make this link to order when it exists.
     thing1.def(
         "order",
         [](WordRange const& self) { return self.order(); },
@@ -405,7 +404,7 @@ The current order of the words in the range.
 Returns the current order of the words in a :any:`WordRange` object.
 
 :returns: The current order.
-:rtype: order
+:rtype: Order
 )pbdoc");
     thing1.def(
         "order",
@@ -477,7 +476,7 @@ Returns whether or not the settings have been changed since the last time either
 Other than by calling :any:`WordRange.next()` , the value returned by :any:`WordRange.get()` may be
 altered by a call to one of the following:
 
-*  ``order(order)``
+*  ``order(Order)``
 *  ``alphabet_size(int)``
 *  ``min(int)``
 *  ``max(int)``
@@ -816,7 +815,7 @@ The current order of the strings in the range.
 Returns the current order of the strings in a :any:`StringRange` object.
 
 :returns: The current order.
-:rtype: order
+:rtype: Order
 )pbdoc");
     thing2.def(
         "order",
@@ -830,7 +829,7 @@ Set the order of the strings in the range.
 Sets the order of the strings in a :any:`StringRange` object to *val*.
 
 :param val: the order.
-:type val: order
+:type val: Order
 
 :returns: A reference to ``self``.
 :rtype: StringRange


### PR DESCRIPTION
This PR makes some minor changes to the doc. Primarily, it fixes the documentation for some overloaded constructors and `init` functions, and resolves from broken links.