### PR TITLE
Bump packaging version to 22.0 to fix setuptools install issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "wheel",
     "pybind11==2.10.1",
     "pkgconfig>=1.5.0",
-    "packaging==20.4",
+    "packaging==22.0",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 graphviz==0.20.1
 jinja2<3.1
 nose==1.3.7
-packaging==21.0
+packaging==22.0
 pkgconfig>=1.5.0
 pybind11==2.10.1
 pyparsing==2.4.7


### PR DESCRIPTION
Was having issues installing the `libsemigroups_pybind11` package earlier today with the error:
```
File "/tmp/pip-build-env-3v2o_037/overlay/lib/python3.12/site-packages/setuptools/_core_metadata.py", line 290, in _distribution_fullname
          canonicalize_version(version, strip_trailing_zero=False),
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
```
As per https://github.com/pypa/setuptools/issues/4483 it seems this has something to do with `setuptools` versions above 71.0 and packaging below version 22.0. As a fix I've bumped the packaging package version.