### PR TITLE
Rename to_string -> to_human_readable_repr for BMat8 + AhoCorasick

### DIFF
--- a/src/aho-corasick.cpp
+++ b/src/aho-corasick.cpp
@@ -63,7 +63,8 @@ Several helper functions are provided in the ``aho_corasick`` module, documented
 :doc:`here <helpers>`.
 )pbdoc");
 
-    thing.def("__repr__", &to_human_readable_repr);
+    thing.def("__repr__",
+              [](auto const& ac) { return to_human_readable_repr(ac); });
 
     thing.attr("root") = &AhoCorasick::root;
 

--- a/src/aho-corasick.cpp
+++ b/src/aho-corasick.cpp
@@ -64,7 +64,7 @@ Several helper functions are provided in the ``aho_corasick`` module, documented
 )pbdoc");
 
     thing.def("__repr__",
-              [](auto const& ac) { return to_human_readable_repr(ac); });
+              [](AhoCorasick const& ac) { return to_human_readable_repr(ac); });
 
     thing.attr("root") = &AhoCorasick::root;
 

--- a/src/aho-corasick.cpp
+++ b/src/aho-corasick.cpp
@@ -63,7 +63,7 @@ Several helper functions are provided in the ``aho_corasick`` module, documented
 :doc:`here <helpers>`.
 )pbdoc");
 
-    thing.def("__repr__", &to_string);
+    thing.def("__repr__", &to_human_readable_repr);
 
     thing.attr("root") = &AhoCorasick::root;
 

--- a/src/bmat8.cpp
+++ b/src/bmat8.cpp
@@ -131,7 +131,8 @@ the submodule ``bmat8``.
     //  2. (self: _libsemigroups_pybind11.FroidurePinBase, w: List[int]) -> int
     //  3. (self: _libsemigroups_pybind11.FroidurePinBase, i: int) -> int
     thing2.def("__len__", [](BMat8 const& x) { return 8; });
-    thing2.def("__repr__", [](BMat8 const& x) { return to_string(x, "[]"); });
+    thing2.def("__repr__",
+               [](BMat8 const& x) { return to_human_readable_repr(x, "[]"); });
     thing2.def(
         "__setitem__",
         [](BMat8& x, std::pair<size_t, size_t> tup, bool val) {


### PR DESCRIPTION
This will likely fail the CI until #216 is merged.