### PR TITLE
Make `add_generating_pair` return `None`

### DIFF
--- a/src/cong-common.cpp
+++ b/src/cong-common.cpp
@@ -465,8 +465,8 @@ number of classes in the congruence represented by a :any:`{name}` instance.
     using Word = typename Thing::native_word_type;
     thing.def(
         "add_generating_pair",
-        [](Thing& self, Word const& u, Word const& v) -> Thing& {
-          return congruence_common::add_generating_pair(self, u, v);
+        [](Thing& self, Word const& u, Word const& v) {
+          congruence_common::add_generating_pair(self, u, v);
         },
         py::arg("u"),
         py::arg("v"),

--- a/src/cong.cpp
+++ b/src/cong.cpp
@@ -64,7 +64,6 @@ individual algorithms, such as :any:`KambitesMultiStringView`,
     >>> is_obviously_infinite(cong)
     True
     >>> cong.add_generating_pair([1, 1, 1], [])
-    <Congruence over <monoid presentation with 2 letters, 1 rule, and length 2> with 4 runners>
     >>> cong.number_of_classes()
     3
     >>> is_obviously_infinite(cong)


### PR DESCRIPTION
This PR implements the Pybind analogue of the changes in https://github.com/libsemigroups/libsemigroups/pull/667