### PR TITLE
Pin setuptools version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ line-length = 80
 lint.ignore = ["F401","E402"]
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools==75.6.0",
     "wheel",
     "pybind11==2.11.1",
     "pkgconfig>=1.5.5",


### PR DESCRIPTION
This is an attempt to fix the issue described here:

https://github.com/libsemigroups/libsemigroups/pull/698

The fact that the version of setuptools is specified in two separate places (requirements.txt and pyproject.toml) is concerning, but maybe we can address that later.