### PR TITLE
Update ci to use the `stable-3.0` branch of `libsemigroups`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           install_ccache: true
       - name: "Install libsemigroups . . ."
         run: |
-          git clone --depth 1 --branch v3 https://github.com/libsemigroups/libsemigroups.git
+          git clone --depth 1 --branch stable-3.0 https://github.com/libsemigroups/libsemigroups.git
           cd libsemigroups
           ./autogen.sh && ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-hpcombi --with-external-fmt && sudo make install -j8
           ccache -s
@@ -102,7 +102,7 @@ jobs:
           install_ccache: true
       - name: "Install libsemigroups . . ."
         run: |
-          git clone --depth 1 --branch v3 https://github.com/libsemigroups/libsemigroups.git
+          git clone --depth 1 --branch stable-3.0 https://github.com/libsemigroups/libsemigroups.git
           cd libsemigroups
           ./autogen.sh 
           ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-hpcombi --with-external-fmt


### PR DESCRIPTION
This PR updates the ci to use the `stable-3.0` branch of `libsemigroups`.