### PR TITLE
added #include <libsemigroups/word-graph-helpers.hpp>

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -30,6 +30,7 @@
 #include <libsemigroups/bmat8.hpp>
 #include <libsemigroups/transf.hpp>
 #include <libsemigroups/word-graph.hpp>
+#include <libsemigroups/word-graph-helpers.hpp>
 
 #include <fmt/core.h>  // for format, print
 

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -29,8 +29,8 @@
 #include <libsemigroups/action.hpp>
 #include <libsemigroups/bmat8.hpp>
 #include <libsemigroups/transf.hpp>
-#include <libsemigroups/word-graph.hpp>
 #include <libsemigroups/word-graph-helpers.hpp>
+#include <libsemigroups/word-graph.hpp>
 
 #include <fmt/core.h>  // for format, print
 

--- a/src/cong.cpp
+++ b/src/cong.cpp
@@ -260,7 +260,7 @@ obviously infinite; ``False`` is returned if it is not.
     congruence has infinitely many classes.
 )pbdoc");
     }  // bind_cong
-  }  // namespace
+  }    // namespace
 
   void init_cong(py::module& m) {
     bind_cong<word_type>(m, "CongruenceWord");

--- a/src/froidure-pin.cpp
+++ b/src/froidure-pin.cpp
@@ -729,7 +729,7 @@ elements are sorted, or :any:`UNDEFINED` if *i* is greater than
 
       // TODO(1) are there some functions missing here?
     }  // bind_froidure_pin
-  }  // namespace
+  }    // namespace
 
   void init_froidure_pin(py::module& m) {
     // TODO(0) uncomment bind_froidure_pin<HPCombiTransf<16>>(m, "Transf16");

--- a/src/gabow.cpp
+++ b/src/gabow.cpp
@@ -33,6 +33,7 @@
 #include <libsemigroups/forest.hpp>            // for Forest
 #include <libsemigroups/gabow.hpp>             // for Gabow
 #include <libsemigroups/word-graph.hpp>        // for WordGraph, word_graph
+#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
 
 // pybind11....
 #include <pybind11/operators.h>  // for self, self_t, operator!=, operator*

--- a/src/gabow.cpp
+++ b/src/gabow.cpp
@@ -32,8 +32,8 @@
 #include <libsemigroups/detail/int-range.hpp>  // for IntegralRange<>::value_type
 #include <libsemigroups/forest.hpp>            // for Forest
 #include <libsemigroups/gabow.hpp>             // for Gabow
-#include <libsemigroups/word-graph.hpp>        // for WordGraph, word_graph
-#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
+#include <libsemigroups/word-graph-helpers.hpp>  // for WordGraph helpers
+#include <libsemigroups/word-graph.hpp>          // for WordGraph, word_graph
 
 // pybind11....
 #include <pybind11/operators.h>  // for self, self_t, operator!=, operator*

--- a/src/kambites.cpp
+++ b/src/kambites.cpp
@@ -231,7 +231,7 @@ defined by a :any:`KambitesMultiStringView` object is obviously infinite;
   presented semigroup or monoid defined by *k* is infinite.
 )pbdoc");
     }  // bind_kambites
-  }  // namespace
+  }    // namespace
 
   void init_kambites(py::module& m) {
     // One call to bind is required per list of types

--- a/src/knuth-bendix-impl.cpp
+++ b/src/knuth-bendix-impl.cpp
@@ -29,6 +29,7 @@
 #include <libsemigroups/runner.hpp>      // for Runner
 #include <libsemigroups/types.hpp>       // for word_type, letter_type
 #include <libsemigroups/word-graph.hpp>  // for WordGraph
+#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
 
 // pybind11....
 #include <pybind11/chrono.h>

--- a/src/knuth-bendix-impl.cpp
+++ b/src/knuth-bendix-impl.cpp
@@ -25,11 +25,11 @@
 // libsemigroups....
 
 #include <libsemigroups/knuth-bendix.hpp>  // for KnuthBendixImpl, KnuthBendixImpl::option...
-#include <libsemigroups/obvinf.hpp>      // for is_obviously_infinite
-#include <libsemigroups/runner.hpp>      // for Runner
-#include <libsemigroups/types.hpp>       // for word_type, letter_type
-#include <libsemigroups/word-graph.hpp>  // for WordGraph
-#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
+#include <libsemigroups/obvinf.hpp>              // for is_obviously_infinite
+#include <libsemigroups/runner.hpp>              // for Runner
+#include <libsemigroups/types.hpp>               // for word_type, letter_type
+#include <libsemigroups/word-graph-helpers.hpp>  // for WordGraph helpers
+#include <libsemigroups/word-graph.hpp>          // for WordGraph
 
 // pybind11....
 #include <pybind11/chrono.h>

--- a/src/knuth-bendix.cpp
+++ b/src/knuth-bendix.cpp
@@ -398,7 +398,7 @@ redundant in this way, then ``None`` is returned.
                 });
       thing.def("next", [](NormalFormRange& nfr) { nfr.next(); });
     }  // bind_normal_form_range
-  }  // namespace
+  }    // namespace
 
   void init_knuth_bendix(py::module& m) {
     using RewriteTrie     = detail::RewriteTrie;

--- a/src/konieczny.cpp
+++ b/src/konieczny.cpp
@@ -641,7 +641,7 @@ not already known.
    int
 )pbdoc");
     }  // bind_konieczny
-  }  // namespace
+  }    // namespace
 
   void init_konieczny(py::module& m) {
     bind_konieczny<BMat8>(m, "BMat8");

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -30,7 +30,7 @@
 #include <libsemigroups/order.hpp>       // for order
 #include <libsemigroups/paths.hpp>       // for Paths
 #include <libsemigroups/word-graph.hpp>  // for WordGraph, word_graph
-
+#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
 // pybind11....
 #include <pybind11/operators.h>  // for self, self_t, operator!=, operator*
 #include <pybind11/pybind11.h>   // for class_, make_iterator, init, enum_

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -26,11 +26,11 @@
 #include <vector>            // for vector
 
 // libsemigroups....
-#include <libsemigroups/constants.hpp>   // for operator!=, operator==
-#include <libsemigroups/order.hpp>       // for order
-#include <libsemigroups/paths.hpp>       // for Paths
-#include <libsemigroups/word-graph.hpp>  // for WordGraph, word_graph
-#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
+#include <libsemigroups/constants.hpp>           // for operator!=, operator==
+#include <libsemigroups/order.hpp>               // for order
+#include <libsemigroups/paths.hpp>               // for Paths
+#include <libsemigroups/word-graph-helpers.hpp>  // for WordGraph helpers
+#include <libsemigroups/word-graph.hpp>          // for WordGraph, word_graph
 // pybind11....
 #include <pybind11/operators.h>  // for self, self_t, operator!=, operator*
 #include <pybind11/pybind11.h>   // for class_, make_iterator, init, enum_

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -1346,7 +1346,7 @@ defined in the alphabet, and that the inverses act as semigroup inverses.
 
 )pbdoc");
     }  // bind_inverse_present
-  }  // namespace
+  }    // namespace
   void init_present(py::module& m) {
     bind_present<word_type>(m, "PresentationWords");
     bind_present<std::string>(m, "PresentationStrings");

--- a/src/schreier-sims.cpp
+++ b/src/schreier-sims.cpp
@@ -446,7 +446,7 @@ corresponding to the intersection of *S1* and *S2*.
 :raises LibsemigroupsError:  if *T* is not empty.
 )pbdoc");
     }  // bind_schreier_sims
-  }  // namespace
+  }    // namespace
 
   void init_schreier_sims(py::module& m) {
     // One call to bind is required per list of types

--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -25,8 +25,8 @@
 #include <libsemigroups/rx/ranges.hpp>  // for rx::begin, rx::end, rx::transform
 #include <libsemigroups/sims.hpp>       // for Sims1, Sims2, ....
 #include <libsemigroups/types.hpp>      // for word_type
-#include <libsemigroups/word-graph.hpp>  // for WordGraph
-#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph Helpers
+#include <libsemigroups/word-graph-helpers.hpp>  // for WordGraph Helpers
+#include <libsemigroups/word-graph.hpp>          // for WordGraph
 
 // pybind11....
 #include <pybind11/functional.h>

--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -26,6 +26,7 @@
 #include <libsemigroups/sims.hpp>       // for Sims1, Sims2, ....
 #include <libsemigroups/types.hpp>      // for word_type
 #include <libsemigroups/word-graph.hpp>  // for WordGraph
+#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph Helpers
 
 // pybind11....
 #include <pybind11/functional.h>

--- a/src/to-cong.cpp
+++ b/src/to-cong.cpp
@@ -23,12 +23,12 @@
 #include <string>  // for string
 
 // libsemigroups headers
-#include <libsemigroups/cong-class.hpp>         // for Congruence
-#include <libsemigroups/froidure-pin-base.hpp>  // for FroidurePinBase
-#include <libsemigroups/to-cong.hpp>            // for to<Congruence>
-#include <libsemigroups/types.hpp>              // for word_type
-#include <libsemigroups/word-graph.hpp>         // for WordGraph
-#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
+#include <libsemigroups/cong-class.hpp>          // for Congruence
+#include <libsemigroups/froidure-pin-base.hpp>   // for FroidurePinBase
+#include <libsemigroups/to-cong.hpp>             // for to<Congruence>
+#include <libsemigroups/types.hpp>               // for word_type
+#include <libsemigroups/word-graph-helpers.hpp>  // for WordGraph helpers
+#include <libsemigroups/word-graph.hpp>          // for WordGraph
 
 // pybind11....
 #include <pybind11/pybind11.h>

--- a/src/to-cong.cpp
+++ b/src/to-cong.cpp
@@ -28,6 +28,7 @@
 #include <libsemigroups/to-cong.hpp>            // for to<Congruence>
 #include <libsemigroups/types.hpp>              // for word_type
 #include <libsemigroups/word-graph.hpp>         // for WordGraph
+#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
 
 // pybind11....
 #include <pybind11/pybind11.h>

--- a/src/to-froidure-pin.cpp
+++ b/src/to-froidure-pin.cpp
@@ -33,6 +33,7 @@
 #include <libsemigroups/transf.hpp>              // for Transf
 #include <libsemigroups/types.hpp>               // for word_type
 #include <libsemigroups/word-graph.hpp>          // for WordGraph
+#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
 
 // pybind11....
 #include <pybind11/pybind11.h>

--- a/src/to-froidure-pin.cpp
+++ b/src/to-froidure-pin.cpp
@@ -32,8 +32,8 @@
 #include <libsemigroups/todd-coxeter-class.hpp>  // for ToddCoxeter
 #include <libsemigroups/transf.hpp>              // for Transf
 #include <libsemigroups/types.hpp>               // for word_type
+#include <libsemigroups/word-graph-helpers.hpp>  // for WordGraph helpers
 #include <libsemigroups/word-graph.hpp>          // for WordGraph
-#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
 
 // pybind11....
 #include <pybind11/pybind11.h>

--- a/src/to-todd-coxeter.cpp
+++ b/src/to-todd-coxeter.cpp
@@ -28,8 +28,8 @@
 #include <libsemigroups/to-todd-coxeter.hpp>     // for to-todd-coxeter
 #include <libsemigroups/todd-coxeter-class.hpp>  // for ToddCoxeter
 #include <libsemigroups/types.hpp>               // for congruence_kind
+#include <libsemigroups/word-graph-helpers.hpp>  // for WordGraph helpers
 #include <libsemigroups/word-graph.hpp>          // for WordGraph
-#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
 
 // pybind11....
 #include <pybind11/pybind11.h>

--- a/src/to-todd-coxeter.cpp
+++ b/src/to-todd-coxeter.cpp
@@ -29,6 +29,7 @@
 #include <libsemigroups/todd-coxeter-class.hpp>  // for ToddCoxeter
 #include <libsemigroups/types.hpp>               // for congruence_kind
 #include <libsemigroups/word-graph.hpp>          // for WordGraph
+#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
 
 // pybind11....
 #include <pybind11/pybind11.h>

--- a/src/todd-coxeter.cpp
+++ b/src/todd-coxeter.cpp
@@ -545,7 +545,7 @@ non-trivial congruence containing the congruence represented by a
 :rtype: tril
  )pbdoc");
     }  // bind_todd_coxeter
-  }  // namespace
+  }    // namespace
 
   void init_todd_coxeter(py::module& m) {
     bind_todd_coxeter<word_type>(m, "ToddCoxeterWord");

--- a/src/word-graph.cpp
+++ b/src/word-graph.cpp
@@ -29,8 +29,8 @@
 #include <libsemigroups/config.hpp>     // for LIBSEMIGROUPS_EIGEN_ENABLED
 #include <libsemigroups/constants.hpp>  // for operator!=, operator==
 #include <libsemigroups/detail/int-range.hpp>  // for IntegralRange<>::value_type
-#include <libsemigroups/word-graph.hpp>        // for WordGraph
-#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
+#include <libsemigroups/word-graph-helpers.hpp>  // for WordGraph helpers
+#include <libsemigroups/word-graph.hpp>          // for WordGraph
 
 // pybind11....
 #include <pybind11/operators.h>  // for self, self_t, operator!=, operator*

--- a/src/word-graph.cpp
+++ b/src/word-graph.cpp
@@ -30,6 +30,7 @@
 #include <libsemigroups/constants.hpp>  // for operator!=, operator==
 #include <libsemigroups/detail/int-range.hpp>  // for IntegralRange<>::value_type
 #include <libsemigroups/word-graph.hpp>        // for WordGraph
+#include <libsemigroups/word-graph-helpers.hpp> // for WordGraph helpers
 
 // pybind11....
 #include <pybind11/operators.h>  // for self, self_t, operator!=, operator*


### PR DESCRIPTION
PyBind checks in libsemigroups were not compiling due to missing #include <libsemigroups/word-graph-helpers.hpp>. This adds this include so that the library builds.