### PR TITLE
Doc: Enable nitpicky

### DIFF
--- a/docs/source/_ext/libsemigroups_pybind11_extensions.py
+++ b/docs/source/_ext/libsemigroups_pybind11_extensions.py
@@ -440,6 +440,7 @@ def check_string_replacements(app, env):
         logger.info(f"Please correct this in {__file__}")
 
 
+# TODO: Check this actually works as expected.
 def document_class(app, what, name, obj, options, lines):
     """Document a class using its __init__ function
 
@@ -450,7 +451,18 @@ def document_class(app, what, name, obj, options, lines):
     if what != "class":
         return
     try:
-        if options["class-doc-from"] == "init":
+        if options["class-doc-from"] != "init":
+            return
+
+        init_doc = obj.__init__.__doc__
+
+        if (
+            not init_doc
+            or "Initialize self.  See help(type(self)) for accurate signature."
+            in init_doc
+        ):
+            lines[:] = []
+        else:
             lines[:] = [f".. autofunction:: {name}.__init__\n"]
     except KeyError:
         return

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name, line-too-long
 """
 This provides configuration for the generation of the docs
 
@@ -16,7 +17,6 @@ following places:
     * mathjax:          https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax
     * sphinx_rtd_theme: https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html
 """
-# pylint: disable=invalid-name
 
 import importlib.metadata
 import sys
@@ -192,7 +192,7 @@ bibtex_bibfiles = ["libsemigroups.bib"]
 
 ############ copybutton ############
 
-# Seeting that means we don't copy the prompt characters like >>> or $
+# Setting that means we don't copy the prompt characters like >>> or $
 copybutton_exclude = ".linenos, .gp"
 
 ############ doctest ############
@@ -204,7 +204,7 @@ ReportGuard(False)"""
 
 ############ intersphinx ############
 
-# Thhe locations and names of other projects that hould be linked to in this
+# Thhe locations and names of other projects that should be linked to in this
 # documentation.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,6 +2,19 @@
 # -*- coding: utf-8 -*-
 """
 This provides configuration for the generation of the docs
+
+More detail of the available configuration options can be found in the
+following places:
+
+    * sphinx:           https://www.sphinx-doc.org/en/master/usage/configuration.html#module-conf
+    * autodoc:          https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#configuration
+    * autosummary:      https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html#generating-stub-pages-automatically
+    * bibtex:           https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#configuration
+    * coppybutton:      https://sphinx-copybutton.readthedocs.io/en/latest/use.html for full info
+    * doctest:          https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html#configuration
+    * intersphinx:      https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
+    * mathjax:          https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax
+    * sphinx_rtd_theme: https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html
 """
 # pylint: disable=invalid-name
 
@@ -9,81 +22,173 @@ import importlib.metadata
 import sys
 from pathlib import Path
 
-# Allows sphinx to use our custom extension
-sys.path.append(str(Path("_ext").resolve()))
+########################################################################
+# sphinx options
+########################################################################
 
-extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.autosummary",
-    "sphinx.ext.doctest",
-    "sphinx.ext.intersphinx",
-    "sphinx.ext.mathjax",
-    "sphinx_copybutton",
-    "sphinxcontrib.bibtex",
-    "libsemigroups_pybind11_extensions",
-]
+############ Project information ############
 
-bibtex_bibfiles = ["libsemigroups.bib"]
+# The documented project’s name
+project = "libsemigroups_pybind11"
 
+# The project’s author(s)
+author = "Joseph Edwards, James Mitchell, Maria Tsalakou, Murray Whyte"
+
+# A copyright statement. The string '%Y' will be replaced with the current
+# four-digit year.
+project_copyright = (
+    "2021-%Y, Joseph Edwards, James Mitchell, Maria Tsalakou, Murray Whyte"
+)
+
+# The major project version, used as the replacement for the |version| default
+# substitution.
+# TODO: We should probably change this so that the we only have the major
+# version, rather than all of the git-related gunk
+version = importlib.metadata.version(project)
+
+# The full project version, used as the replacement for the |release| default
+# substitution.
+release = version
+
+############ Options for highlighting ############
+
+# The default language to highlight source code in.
+highlight_language = "python"
+
+# The style name to use for Pygments highlighting of source code.
+pygments_style = "sphinx"
+
+############ Options for markup ############
+
+# A string of reStructuredText that will be included at the end of every source
+# file that is read.
 rst_epilog = ""
 # Read link all targets from file
 with open("_static/links.rst", encoding="utf-8") as f:
     rst_epilog += f.read()
 
-autosummary_generate = True
+
+############ Options for source files ############
+
+# A list of glob-style patterns that should be excluded when looking for source
+# files.
+exclude_patterns = ["_build", "_old", "_static"]
+
+# The name of the document containing the master toctree directive, and hence
+# the root of the entire tree.
+master_doc = "index"
+
+# A dictionary mapping the file extensions (suffixes) of source files to
+# their file types.
+source_suffix = {".rst": "restructuredtext"}
+
+############ Options for  HTML output ############
+
+# The theme for HTML output.
+html_theme = "sphinx_rtd_theme"
+
+# A dictionary of options that influence the look and feel of the selected
+# theme.
+# The titles_only option stops the page sections and toc (which have the
+# same names) from being duplicated in the sidebar on the Konieczny and
+# FroidurePin pages.
+html_theme_options = {
+    "titles_only": True,
+    "style_nav_header_background": "#2980B9",
+}
+
+# The project logo
+html_logo = "../pictures/libsemigroups_pybind11_logo.svg"
+
+# The project favicon
+html_favicon = html_logo
+
+# A list of CSS files.
+html_css_files = ["custom.css"]
+
+# A list of paths that contain custom static files (such as style sheets or
+# script files).
+html_static_path = ["_static"]
+
+############ Options for HTML help output ############
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = "libsemigroups_pybind11"
+
+############ Options for manual page output ############
+
+# How to group the document tree into manual pages.
+man_pages = [
+    (
+        master_doc,
+        "libsemigroups_pybind11",
+        "libsemigroups_pybind11 Documentation",
+        author,
+        1,
+    )
+]
+
+############ Options for the Python domain ############
+
+
+# A boolean that decides whether module names are prepended to all object names.
 # We set this to True here, but remove "libsemigroups_pybind11\..*" from the doc
 # everywhere. This is done so we still get the submodule names, but not the
 # global module name. A nicer, but more involved solution, could use some Sphinx
 # magic as done in https://stackoverflow.com/a/72658470/15278419.
 add_module_names = True
 
-templates_path = ["_templates"]
-source_suffix = ".rst"
-master_doc = "index"
-project = "libsemigroups_pybind11"
-copyright = "2021-2025, Joseph Edwards, James Mitchell, Maria Tsalakou, Murray Whyte"  # pylint: disable=redefined-builtin
-author = "Joseph Edwards, James Mitchell, Maria Tsalakou, Murray Whyte"
-# Use the version number of the installed project
-version = release = importlib.metadata.version(project)
-language = "python"
-exclude_patterns = ["_build", "_old", "_static"]
-# Don't copy the prompt characters
-copybutton_exclude = ".linenos, .gp"
-pygments_style = "sphinx"
-highlight_language = "python"
-todo_include_todos = False
+########################################################################
+# Extension options
+########################################################################
 
-html_theme = "sphinx_rtd_theme"
-htmlhelp_basename = "libsemigroups_pybind11"
+# Allows sphinx to use our custom extension
+sys.path.append(str(Path("_ext").resolve()))
 
-html_static_path = ["_static"]
-html_css_files = ["custom.css"]
-
-# The option in the next line stops the page sections and toc (which have the
-# same names) from being duplicated in the sidebar on the Konieczny and
-# FroidurePin pages
-html_theme_options = {"titles_only": True}
-
-html_logo = "../pictures/libsemigroups_pybind11_logo.svg"
-html_favicon = html_logo
-
-
-man_pages = [
-    (
-        master_doc,
-        "libsemigroups_pybind11",
-        "libsemigroups_pybind11 Documentation",
-        [author],
-        1,
-    )
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinxcontrib.bibtex",
+    "sphinx_copybutton",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "libsemigroups_pybind11_extensions",
 ]
 
+############ autodoc ############
+
+# What content will be inserted into the main body of an autoclass directive.
+autoclass_content = "class"
+
+############ autosummary ############
+
+# Boolean indicating whether to scan all found documents for autosummary
+# directives, and to generate stub pages for each.
+autosummary_generate = False
+
+############ bibtex ############
+
+# List of bib files
+bibtex_bibfiles = ["libsemigroups.bib"]
+
+############ copybutton ############
+
+# Seeting that means we don't copy the prompt characters like >>> or $
+copybutton_exclude = ".linenos, .gp"
+
+############ doctest ############
+
+# Python code that is treated like it were put in a testsetup directive for
+# every file that is tested, and for every group.
+doctest_global_setup = """from libsemigroups_pybind11 import ReportGuard
+ReportGuard(False)"""
+
+############ intersphinx ############
+
+# Thhe locations and names of other projects that hould be linked to in this
+# documentation.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
-
-autoclass_content = "class"
-
-doctest_global_setup = """from libsemigroups_pybind11 import ReportGuard
-ReportGuard(False)"""

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,6 +67,24 @@ rst_epilog = ""
 with open("_static/links.rst", encoding="utf-8") as f:
     rst_epilog += f.read()
 
+############ Options for nitpicky mode ############
+
+# In nitpicky mode, Sphinx will warn about all references where the target
+# cannot be found.
+nitpicky = True
+
+# A set or list of (warning_type, target) tuples that should be ignored when
+# generating warnings in "nitpicky mode".
+# See https://github.com/sphinx-doc/sphinx/issues/10785 for why the numpy ones
+# don't work.
+nitpick_ignore = {
+    ("py:class", "Element"),
+    ("py:class", "Letter"),
+    ("py:class", "Point"),
+    ("py:class", "Range"),
+    ("py:class", "Word"),
+    ("py:class", "numpy.float64"),
+}
 
 ############ Options for source files ############
 

--- a/docs/source/main-algorithms/core-classes/runner.rst
+++ b/docs/source/main-algorithms/core-classes/runner.rst
@@ -42,7 +42,6 @@ Full API
 --------
 
 .. autoclass:: Runner
-    :no-doc:
     :class-doc-from: init
     :members:
     :exclude-members: state

--- a/docs/source/main-algorithms/knuth-bendix/helpers.rst
+++ b/docs/source/main-algorithms/knuth-bendix/helpers.rst
@@ -14,7 +14,7 @@ submodule ``libsemigroups_pybind11.knuth_bendix``.
 
 .. seealso::
 
-    :py:class:`overlap`
+    :any:`KnuthBendix.options`
 
 Contents
 --------

--- a/docs/source/main-algorithms/schreier-sims/class.rst
+++ b/docs/source/main-algorithms/schreier-sims/class.rst
@@ -51,8 +51,8 @@ Full API
     :class-doc-from: init
     :members:
     :exclude-members: 
-        current_state, dead, finished, internal_generating_pairs,
+        current_state, dead, internal_generating_pairs,
         kill, last_report, report, report_every, report_prefix,
-        report_why_we_stopped, reset_last_report, reset_start_time, run, run_for,
+        report_why_we_stopped, reset_last_report, reset_start_time, run_for,
         run_until, running, running_for, running_until, start_time, started, state,
         stopped, stopped_by_predicate, success, timed_out

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -523,18 +523,30 @@ This function returns the point obtained by applying the action defined by
   }  // namespace
 
   void init_action(py::module& m) {
-    py::enum_<side>(
-        m,
-        "side",
-        R"pbdoc(This value indicates that the action in an :any:`Action` instance should be a left action.)pbdoc")
-        .value(
-            "left",
-            side::left,
-            R"pbdoc(This value indicates that the action in an :any:`Action` instance should be a left action.)pbdoc")
-        .value(
-            "right",
-            side::right,
-            R"pbdoc(This value indicates that the action in an :any:`Action` instance should be a right action.)pbdoc");
+    py::options options;
+    options.disable_enum_members_docstring();
+    py::enum_<side>(m,
+                    "side",
+                    R"pbdoc(
+The values in this enum can be used to indicate that the action in an
+:any:`Action` instance should be a left action.
+
+The valid values are:
+
+.. py:attribute:: side.left
+  :value: <side.left: 0>
+
+   Value indicating that the action in an :any:`Action` instance should be a
+   left action.
+
+.. py:attribute:: side.right
+  :value: <side.left: 1>
+
+   Value indicating that the action in an :any:`Action` instance should be a
+   right action.
+)pbdoc")
+        .value("left", side::left)
+        .value("right", side::right);
 
     // One call to bind is required per list of types
 

--- a/src/bmat8.cpp
+++ b/src/bmat8.cpp
@@ -49,11 +49,6 @@ be ``0``. This does not affect the results of any calculations.
 There are numerous functions for computing things about :any:`BMat8` objects in
 the submodule ``bmat8``.
 
-.. toctree::
-   :maxdepth: 1
-
-   bmat8-helpers
-
 .. doctest::
 
    >>> from libsemigroups_pybind11 import BMat8

--- a/src/forest.cpp
+++ b/src/forest.cpp
@@ -162,7 +162,7 @@ Returns the label of the edge from a node to its parent.
 :param i:
    the node whose label is sought.
 :type i:
-  init
+  int
 
 :returns:
    The label of the edge from the parent of *i* to *i*.

--- a/src/froidure-pin-base.cpp
+++ b/src/froidure-pin-base.cpp
@@ -762,7 +762,7 @@ use :any:`current_rules` instead.
 :returns:
     An iterator yielding rules.
 :rtype:
-    Iterator[tuple[list[int],list[int]]]:
+    Iterator[tuple[list[int],list[int]]]
 )pbdoc");
     }
   }  // init_froidure_pin_base

--- a/src/froidure-pin.cpp
+++ b/src/froidure-pin.cpp
@@ -346,16 +346,66 @@ element of *fp* and ``False`` otherwise.
             return froidure_pin::factorisation(fpb, pos);
           },
           py::arg("fpb"),
-          py::arg("pos"));
+          py::arg("pos"),
+          R"pbdoc(
+:sig=(fp: FroidurePin, x: Element | int) -> list[int]:
+:only-document-once:
 
-      // Documented in the Element overload.
+Returns a word containing a factorisation (in the generators) of an
+element.
+
+This function returns a word in the generators that equals the given element
+*x*. The key difference between this function and :any:`minimal_factorisation`,
+is that the resulting factorisation may not be minimal.
+
+:param fp: the :any:`FroidurePin` instance.
+:type fp: FroidurePin
+
+:param x: a possible element, or index of element, to factorise.
+:type x: Element | int
+
+:returns: Returns a word in the generators which evaluates to *x*.
+:rtype: list[int]
+
+:raises LibsemigroupsError:
+  if *x* is an ``Element`` and *x* does not belong to *fp*.
+
+:raises LibsemigroupsError:
+  if *x* is an :any:`int` and *x* is greater than or equal to :any:`FroidurePin.size`.
+
+)pbdoc");
+
       m.def(
           "froidure_pin_minimal_factorisation",
           [](FroidurePin_& fp, size_t i) {
             return froidure_pin::minimal_factorisation(fp, i);
           },
           py::arg("fp"),
-          py::arg("i"));
+          py::arg("i"),
+          R"pbdoc(
+:sig=(fp: FroidurePin, x: Element | int) -> list[int]:
+:only-document-once:
+Returns a word containing a minimal factorisation (in the generators)
+of an element.
+
+This function returns the short-lex minimum word (if any) in the generators
+that evaluates to *x*.
+
+:param fp: the :any:`FroidurePin` instance.
+:type fp: FroidurePin
+
+:param x: a possible element, or index of element, to factorise.
+:type x: Element | int
+
+:returns: A word in the generators that evaluates to *x*.
+:rtype: list[int]
+
+:raises LibsemigroupsError:
+  if *x* is an ``Element`` and *x* does not belong to *fp*.
+
+:raises LibsemigroupsError:
+  if *x* is an :any:`int` and *x* is greater than or equal to :any:`FroidurePin.size`.
+)pbdoc");
 
       m.def(
           "froidure_pin_position",
@@ -875,6 +925,7 @@ if *x* is not an element.
       // Helper functions
       ////////////////////////////////////////////////////////////////////////
 
+      // Documented in the size_t overload.
       m.def(
           "froidure_pin_factorisation",
           [](FroidurePin_& fp, Element const& x) {
@@ -884,29 +935,6 @@ if *x* is not an element.
           py::arg("x"),
           R"pbdoc(
 :sig=(fp: FroidurePin, x: Element | int) -> list[int]:
-:only-document-once:
-
-Returns a word containing a factorisation (in the generators) of an
-element.
-
-This function returns a word in the generators that equals the given element
-*x*. The key difference between this function and :any:`minimal_factorisation`,
-is that the resulting factorisation may not be minimal.
-
-:param fp: the :any:`FroidurePin` instance.
-:type fp: FroidurePin
-
-:param x: a possible element, or index of element, to factorise.
-:type x: Element | int
-
-:returns: Returns a word in the generators which evaluates to *x*.
-:rtype: list[int]
-
-:raises LibsemigroupsError:
-  if *x* is an ``Element`` and *x* does not belong to *fp*.
-
-:raises LibsemigroupsError:
-  if *x* is an :any:`int` and *x* is greater than or equal to :any:`FroidurePin.size`.
 )pbdoc");
 
       m.def(
@@ -918,28 +946,6 @@ is that the resulting factorisation may not be minimal.
           py::arg("x"),
           R"pbdoc(
 :sig=(fp: FroidurePin, x: Element | int) -> list[int]:
-:only-document-once:
-
-Returns a word containing a minimal factorisation (in the generators)
-of an element.
-
-This function returns the short-lex minimum word (if any) in the generators
-that evaluates to *x*.
-
-:param fp: the :any:`FroidurePin` instance.
-:type fp: FroidurePin
-
-:param x: a possible element, or index of element, to factorise.
-:type x: Element | int
-
-:returns: A word in the generators that evaluates to *x*.
-:rtype: list[int]
-
-:raises LibsemigroupsError:
-  if *x* is an ``Element`` and *x* does not belong to *fp*.
-
-:raises LibsemigroupsError:
-  if *x* is an :any:`int` and *x* is greater than or equal to :any:`FroidurePin.size`.
 )pbdoc");
 
       m.def(
@@ -1219,26 +1225,41 @@ This function returns the element of *fp* obtained by evaluating *w*.
         // Helpers
         ////////////////////////////////////////////////////////////////////////
 
-        m.def("froidure_pin_factorisation",
-              [](FroidurePin_& fp, ElementStateful<FroidurePin_> const& x) {
-                return froidure_pin::factorisation(fp, to_element(x));
-              });
+        m.def(
+            "froidure_pin_factorisation",
+            [](FroidurePin_& fp, ElementStateful<FroidurePin_> const& x) {
+              return froidure_pin::factorisation(fp, to_element(x));
+            },
+            R"pbdoc(
+:sig=(fp: FroidurePin, x: Element | int) -> list[int]:
+)pbdoc");
 
-        m.def("froidure_pin_factorisation",
-              [](FroidurePin_& fp, Word const& x) {
-                return froidure_pin::factorisation(fp, to_element(fp, x));
-              });
+        m.def(
+            "froidure_pin_factorisation",
+            [](FroidurePin_& fp, Word const& x) {
+              return froidure_pin::factorisation(fp, to_element(fp, x));
+            },
+            R"pbdoc(
+:sig=(fp: FroidurePin, x: Element | int) -> list[int]:
+)pbdoc");
 
-        m.def("froidure_pin_minimal_factorisation",
-              [](FroidurePin_& fp, ElementStateful<FroidurePin_> const& x) {
-                return froidure_pin::minimal_factorisation(fp, to_element(x));
-              });
+        m.def(
+            "froidure_pin_minimal_factorisation",
+            [](FroidurePin_& fp, ElementStateful<FroidurePin_> const& x) {
+              return froidure_pin::minimal_factorisation(fp, to_element(x));
+            },
+            R"pbdoc(
+:sig=(fp: FroidurePin, x: Element | int) -> list[int]:
+)pbdoc");
 
-        m.def("froidure_pin_minimal_factorisation",
-              [](FroidurePin_& fp, Word const& x) {
-                return froidure_pin::minimal_factorisation(fp,
-                                                           to_element(fp, x));
-              });
+        m.def(
+            "froidure_pin_minimal_factorisation",
+            [](FroidurePin_& fp, Word const& x) {
+              return froidure_pin::minimal_factorisation(fp, to_element(fp, x));
+            },
+            R"pbdoc(
+:sig=(fp: FroidurePin, x: Element | int) -> list[int]:
+)pbdoc");
 
         m.def("froidure_pin_to_element",
               [](FroidurePin_& fp, word_type const& w) {
@@ -1246,7 +1267,7 @@ This function returns the element of *fp* obtained by evaluating *w*.
               });
       }
     }  // bind_froidure_pin_stateful
-  }  // namespace
+  }    // namespace
 
   void init_froidure_pin(py::module& m) {
     // TODO(0) uncomment bind_froidure_pin<HPCombiTransf<16>>(m, "Transf16");

--- a/src/knuth-bendix-impl.cpp
+++ b/src/knuth-bendix-impl.cpp
@@ -64,9 +64,11 @@ namespace libsemigroups {
       py::class_<typename KnuthBendixImpl<Rewriter>::options> options(thing,
                                                                       "options",
                                                                       R"pbdoc(
-This class containing various options that can be used to control the
+This class contains various options that can be used to control the
 behaviour of Knuth-Bendix.)pbdoc");
 
+      py::options enum_options;
+      enum_options.disable_enum_members_docstring();
       py::enum_<typename KnuthBendixImpl<Rewriter>::options::overlap>(options,
                                                                       "overlap",
                                                                       R"pbdoc(
@@ -78,17 +80,29 @@ The values in this enum determine how a :any:`KnuthBendix`
 instance measures the length :math:`d(AB, BC)` of the overlap of
 two words :math:`AB` and :math:`BC`.
 
+The valid values are:
+
+.. py:attribute:: overlap.ABC
+  :value: <overlap.ABC: 0>
+
+  :math:`d(AB, BC) = |A| + |B| + |C|`
+
+.. py:attribute:: overlap.AB_BC
+  :value: <overlap.AB_BC: 1>
+
+  :math:`d(AB, BC) = |AB| + |BC|`
+
+.. py:attribute:: overlap.MAX_AB_BC
+  :value: <overlap.MAX_AB_BC: 2>
+
+  :math:`d(AB, BC) = max(|AB|, |BC|)`
+
 .. seealso:: :any:`KnuthBendix.overlap_policy`
 )pbdoc")
-          .value("ABC",
-                 KnuthBendixImpl<Rewriter>::options::overlap::ABC,
-                 R"pbdoc(:math:`d(AB, BC) = |A| + |B| + |C|`)pbdoc")
-          .value("AB_BC",
-                 KnuthBendixImpl<Rewriter>::options::overlap::AB_BC,
-                 R"pbdoc(:math:`d(AB, BC) = |AB| + |BC|`)pbdoc")
+          .value("ABC", KnuthBendixImpl<Rewriter>::options::overlap::ABC)
+          .value("AB_BC", KnuthBendixImpl<Rewriter>::options::overlap::AB_BC)
           .value("MAX_AB_BC",
-                 KnuthBendixImpl<Rewriter>::options::overlap::MAX_AB_BC,
-                 R"pbdoc(:math:`d(AB, BC) = max(|AB|, |BC|)`)pbdoc");
+                 KnuthBendixImpl<Rewriter>::options::overlap::MAX_AB_BC);
 
       thing.def("__repr__", [](KnuthBendixImpl<Rewriter>& self) {
         return to_human_readable_repr(self);

--- a/src/konieczny.cpp
+++ b/src/konieczny.cpp
@@ -78,7 +78,10 @@ Copy a Konieczny.
 )pbdoc");
 
       // This constructor can't be used directly so isn't documented.
-      thing.def(py::init<>());
+      thing.def(py::init<>(), R"pbdoc(
+:sig=(self: Konieczny, gens: list[Element]) -> None:
+:only-document-once:
+)pbdoc");
 
       thing.def(py::init([](std::vector<Element> const& gens) {
                   return make<Konieczny>(gens);
@@ -86,6 +89,7 @@ Copy a Konieczny.
                 py::arg("gens"),
                 R"pbdoc(
 :sig=(self: Konieczny, gens: list[Element]) -> None:
+:only-document-once:
 
 Construct from generators.
 
@@ -722,7 +726,7 @@ not already known.
    int
 )pbdoc");
     }  // bind_konieczny
-  }  // namespace
+  }    // namespace
 
   void init_konieczny(py::module& m) {
     bind_konieczny<BMat8>(m, "BMat8");

--- a/src/libsemigroups_pybind11/action.py
+++ b/src/libsemigroups_pybind11/action.py
@@ -191,7 +191,7 @@ class Action(_CxxWrapper):  # pylint: disable=missing-class-docstring
             * **generators** (*list[Element]*)-- at least one generator for the action.
             * **seeds** (*list[Point]*) -- at least one seed point for the action.
             * **func** (*Callable[[Point, Element], Point]*) -- the function defining the action.
-            * **side** (:py:class:`side <side>`)-- the side of the action.
+            * **side** (:any:`side`)-- the side of the action.
 
         :raises TypeError:
             if *generators* or *seeds* is not a list.
@@ -291,7 +291,7 @@ class RightAction(Action):
 
     This page contains the documentation for the class :any:`RightAction`,
     which just calls :any:`Action` with the keyword arguments *func* given by
-    :any:`ImageRightAction` and *side* given by :py:class:`side.right`.
+    :any:`ImageRightAction` and *side* given by :any:`side.right`.
     """
 
     def __init__(self: _Self, *args, generators=None, seeds=None) -> None:
@@ -299,7 +299,7 @@ class RightAction(Action):
         :sig=(self: RightAction, generators=None, seeds=None) -> None:
 
         Construct an :any:`Action` from generators and seeds,
-        :any:`ImageRightAction` and :py:class:`side.right`.
+        :any:`ImageRightAction` and :any:`side.right`.
 
         :Keyword Arguments:
 
@@ -337,7 +337,7 @@ class LeftAction(Action):
 
     This page contains the documentation for the class ``LeftAction``, which
     just calls :any:`Action` with the keyword arguments *func* given by
-    :any:`ImageLeftAction` and *side* given by :py:class:`side.left`.
+    :any:`ImageLeftAction` and *side* given by :any:`side.left`.
     """
 
     def __init__(self: _Self, *args, generators=None, seeds=None) -> None:
@@ -345,7 +345,7 @@ class LeftAction(Action):
         :sig=(self: LeftAction, generators=None, seeds=None) -> None:
 
         Construct an :any:`Action` from generators and seeds,
-        :any:`ImageLeftAction` and :py:class:`side.left`.
+        :any:`ImageLeftAction` and :any:`side.left`.
 
         :Keyword Arguments:
 

--- a/src/libsemigroups_pybind11/sims.py
+++ b/src/libsemigroups_pybind11/sims.py
@@ -226,6 +226,10 @@ class SimsRefinerIdeals(_SimsBase):  # pylint: disable=missing-class-docstring
     def __init__(self: _Self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
+    @_copydoc(_SimsRefinerIdeals.__call__)
+    def __call__(self: _Self, *args, **kwargs) -> bool:
+        return super().__call__(*args, **kwargs)
+
 
 _copy_cxx_mem_fns(_SimsRefinerIdeals, SimsRefinerIdeals)
 _register_cxx_wrapped_type(_SimsRefinerIdeals, SimsRefinerIdeals)
@@ -291,6 +295,10 @@ class SimsRefinerFaithful(
                     "expected the 1st argument to be a list[list[int]]"
                 )
         self.init_cxx_obj(*args)
+
+    @_copydoc(_SimsRefinerFaithful.__call__)
+    def __call__(self: _Self, *args, **kwargs) -> bool:
+        return super().__call__(*args, **kwargs)
 
 
 _copy_cxx_mem_fns(_SimsRefinerFaithful, SimsRefinerFaithful)

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -170,9 +170,8 @@ namespace libsemigroups {
 This page contains the documentation for functionality in
 ``libsemigroups_pybind11`` for matrices.
 
-Matrices over various semirings can be constructed using the function
-:py:class:`Matrix`. :py:class:`Matrix` is a function that returns an instance of
-one of a number of internal classes. These internal types are optimised in
+Matrices over various semirings can be constructed using the class
+:py:class:`Matrix`. These internal types are optimised in
 various ways so that the underlying semiring operations are as fast as possible.
 
 Some helper functions for :py:class:`Matrix` objects are documented in the
@@ -521,7 +520,7 @@ Multiply two matrices and stores the product in *self*.
 :raises LibsemigroupsError:
   if *x* and *y* are not square, or do not have the same number of rows.
 
-:raises RunTimeError:
+:raises TypeError:
   if *x* and *y* are not defined over the same semiring.)pbdoc");
       thing.def(
           "transpose",
@@ -685,9 +684,9 @@ Construct a matrix from rows.
 :type rows: list[list[int | PositiveInfinity | NegativeInfinity]]
 
 :raise TypeError: if *kind* is
-    :py:attr:`MatrixKind.MaxPlusTrunc`,
-    :py:attr:`MatrixKind.MinPlusTrunc`, or
-    :py:attr:`MatrixKind.NTP`.
+    :any:`MatrixKind.MaxPlusTrunc`,
+    :any:`MatrixKind.MinPlusTrunc`, or
+    :any:`MatrixKind.NTP`.
 
 :raise LibsemigroupsError:
   if the entries in *rows* are not of equal length.
@@ -711,10 +710,10 @@ Construct an uninitialized *r* by *c* matrix.
 :param c: the number of columns in the matrix.
 :type c: int
 
-:raise RunTimeError: if *kind* is
-    :py:attr:`MatrixKind.MaxPlusTrunc`,
-    :py:attr:`MatrixKind.MinPlusTrunc`,
-    or :py:attr:`MatrixKind.NTP`.
+:raise TypeError: if *kind* is
+    :any:`MatrixKind.MaxPlusTrunc`,
+    :any:`MatrixKind.MinPlusTrunc`,
+    or :any:`MatrixKind.NTP`.
 
 .. doctest::
 
@@ -754,9 +753,9 @@ Construct an uninitialized `r` by `c` matrix.
 :param c: the number of columns in the matrix
 :type c: int
 
-:raise RunTimeError:
-  if *kind* is not :py:attr:`MatrixKind.MaxPlusTrunc` or
-  :py:attr:`MatrixKind.MinPlusTrunc`.
+:raise TypeError:
+  if *kind* is not :any:`MatrixKind.MaxPlusTrunc` or
+  :any:`MatrixKind.MinPlusTrunc`.
 
 .. doctest::
 
@@ -787,9 +786,9 @@ Construct a matrix from threshold and rows.
 :param rows: the rows of the matrix.
 :type rows: list[list[int | PositiveInfinity | NegativeInfinity]]
 
-:raise RunTimeError:
-    if *kind* is not :py:attr:`MatrixKind.MaxPlusTrunc` or
-    :py:attr:`MatrixKind.MinPlusTrunc`.
+:raise TypeError:
+    if *kind* is not :any:`MatrixKind.MaxPlusTrunc` or
+    :any:`MatrixKind.MinPlusTrunc`.
 
 :raise LibsemigroupsError:
   if the entries in *rows* are not of equal length.
@@ -861,7 +860,7 @@ Construct a matrix from threshold, period, and rows.
 :param rows: the rows of the matrix.
 :type rows: list[list[int]]
 
-:raise RunTimeError: if *kind* is not :py:attr:`MatrixKind.NTP`.
+:raise TypeError: if *kind* is not :any:`MatrixKind.NTP`.
 
 :raise LibsemigroupsError:
   if the entries in *rows* are not of equal length.
@@ -893,7 +892,7 @@ Construct an uninitialized `r` by `c` matrix with threshold and period.
 :param c: the number of columns in the matrix.
 :type c: int
 
-:raise RunTimeError: if *kind* is not :py:attr:`MatrixKind.NTP`.
+:raise TypeError: if *kind* is not :any:`MatrixKind.NTP`.
 
 .. doctest::
 
@@ -951,22 +950,8 @@ the ntp matrix *x* using its underlying semiring.
           [](Mat const& x) { return matrix::threshold(x); },
           py::arg("x"),
           R"pbdoc(
-:sig=(x:Matrix)->int:
+:sig=(x: Matrix) -> int:
 :only-document-once:
-Returns the threshold of a matrix over a truncated semiring.
-
-This function returns the threshold of a matrix over a truncated semiring,
-that is a matrix whose kind is any of:
-
-* :any:`MatrixKind.MaxPlusTrunc`
-* :any:`MatrixKind.MinPlusTrunc`
-* :any:`MatrixKind.NTP`
-
-:param x: the matrix.
-:type x: Mat
-
-:returns: The threshold of *x*.
-:rtype: int
 )pbdoc");
     }
   }  // namespace
@@ -1020,6 +1005,7 @@ the size of the row space of the boolean matrix *x*.
         py::arg("x"),
         R"pbdoc(
 :sig=(x: Matrix) -> list[list[int | PositiveInfinity | NegativeInfinity]]:
+:only-document-once:
 Returns a row space basis of a matrix as a list of lists. The matrix *x* which
 must be one of:
 
@@ -1040,14 +1026,20 @@ of rows.
 :rtype: list[list[int | PositiveInfinity | NegativeInfinity]]
 )pbdoc");
 
-    m.def("matrix_row_basis", [](MaxPlusTruncMat<0, 0, 0, int64_t> const& x) {
-      std::vector<std::vector<int_or_signed_constant<int64_t>>> result;
-      for (auto rv : matrix::row_basis(x)) {
-        result.emplace_back(rv.begin(), rv.end());
-        from_ints<int64_t>(result.back());
-      }
-      return result;
-    });
+    m.def(
+        "matrix_row_basis",
+        [](MaxPlusTruncMat<0, 0, 0, int64_t> const& x) {
+          std::vector<std::vector<int_or_signed_constant<int64_t>>> result;
+          for (auto rv : matrix::row_basis(x)) {
+            result.emplace_back(rv.begin(), rv.end());
+            from_ints<int64_t>(result.back());
+          }
+          return result;
+        },
+        R"pbdoc(
+:sig=(x: Matrix) -> list[list[int | PositiveInfinity | NegativeInfinity]]:
+:only-document-once:
+)pbdoc");
   }
 
 }  // namespace libsemigroups

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -79,6 +79,7 @@ Data member holding the rules of the presentation.
 The rules can be altered using the member functions of ``list``, and the
 presentation can be checked for validity using :any:`throw_if_bad_alphabet_or_rules`.)pbdoc");
       thing.def(py::init<>(), R"pbdoc(
+:sig=(self: Presentation) -> None:
 Default constructor.
 
 Constructs an empty presentation with no rules and no alphabet.)pbdoc");
@@ -115,7 +116,7 @@ Return the alphabet of the presentation.
           },
           py::arg("n"),
           R"pbdoc(
-:sig=(self: Presentation, int: n) -> Presentation:
+:sig=(self: Presentation, n: int) -> Presentation:
 Set the alphabet by size.
 
 Sets the alphabet to the the first :math:`n` values with type
@@ -398,7 +399,7 @@ Add the letter *x* as a generator.
 :type x: :ref:`Letter<pseudo_letter_type_class>`
 
 :returns: *self*.
-:rtype: Presentation.
+:rtype: Presentation
 
 :raises LibsemigroupsError:  if *x* is in ``alphabet()``.)pbdoc");
       thing.def(
@@ -415,7 +416,7 @@ Remove the letter *x* as a generator.
 :type x: :ref:`Letter<pseudo_letter_type_class>`
 
 :returns: *self*.
-:rtype: Presentation.
+:rtype: Presentation
 
 :raises LibsemigroupsError: if *x* is not in `p.alphabet()`.
 
@@ -815,7 +816,7 @@ If no such word can be found, then a word of length :math:`0` is returned.
 :type p: Presentation
 
 :returns: the longest common subword, if it exists.
-:rtype: :ref:`Word<pseudo_word_type_helper>`.
+:rtype: :ref:`Word<pseudo_word_type_helper>`
 
 )pbdoc");
       m.def(
@@ -1276,6 +1277,7 @@ This class inherits from :any:`Presentation`.)pbdoc");
         return to_human_readable_repr(p);
       });
       thing.def(py::init<Presentation<Word> const&>(), R"pbdoc(
+:sig=(self: InversePresentation, p: Presentation) -> None:
 Construct an InversePresentation from a Presentation.
 
 Construct an :any:`InversePresentation`, initially with empty inverses,
@@ -1285,6 +1287,7 @@ from a :any:`Presentation`.
 :type p: Presentation
 )pbdoc");
       thing.def(py::init<>(), R"pbdoc(
+:sig=(self: InversePresentation) -> None:
 Default constructor.
 
 Constructs an empty :any:`InversePresentation` with no rules, no alphabet and
@@ -1392,7 +1395,7 @@ defined in the alphabet, and that the inverses act as semigroup inverses.
       * :any:`presentation.throw_if_bad_inverses`
 )pbdoc");
     }  // bind_inverse_present
-  }  // namespace
+  }    // namespace
 
   void init_present(py::module& m) {
     bind_present<word_type>(m, "PresentationWord");

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -34,12 +34,12 @@ namespace libsemigroups {
 Objects of this type can be used to enable printing of some information
 during various of the computation in ``libsemigroups_pybind11``. Reporting
 is enabled (or not) at construction time, and disable when the
-:py:class:`ReportGuard` goes out of scope.
+:any:`ReportGuard` goes out of scope.
       )pbdoc")
         .def(py::init<bool>(),
              py::arg("val") = true,
              R"pbdoc(
-Constructs a :py:class:`ReportGuard` with reporting enabled by
+Constructs a :any:`ReportGuard` with reporting enabled by
 default.
 
 :param val:

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -397,10 +397,10 @@ any derived class of :any:`Runner`.
 Run until a nullary predicate returns true or finished.
 
 :param func:
-   a function pointer.
+   a nullary function that will be used to determine when to stop running.
 
 :type func:
-   bool(*)()
+   Callable[[], bool]
 )pbdoc");
     thing.def("timed_out",
               &Runner::timed_out,

--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -698,7 +698,7 @@ search conducted by an object of this type.
 
 :raises LibsemigroupsError:  if *p* has 0-generators and 0-relations.
 
-.. seealso:: :py:meth:`~Sims1.presentation`, :py:meth:`~Sims1.init`
+.. seealso:: :any:`Sims1.presentation`, :any:`Sims1.init`
 )pbdoc");
 
     s1.def("__copy__", [](Sims1 const& self) { return Sims1(self); });
@@ -934,7 +934,7 @@ search conducted by an object of this type.
 
 :raises LibsemigroupsError: if *p* has 0-generators and 0-relations.
 
-.. seealso:: :py:meth:`~Sims2.presentation`, :py:meth:`~Sims2.init`
+.. seealso:: :any:`Sims2.presentation`, :any:`Sims2.init`
 )pbdoc");
 
     s2.def(
@@ -1234,7 +1234,7 @@ Set the target size.
 
 This function sets the target size, i.e. the desired size of the transformation
 semigroup corresponding to the :any:`WordGraph` returned by the function
-:py:meth:`~Sims1.word_graph`.
+:py:meth:`~RepOrc.word_graph`.
 
 :param val: the target size.
 :type val: int
@@ -1280,9 +1280,8 @@ action of the semigroup or monoid defined by the presentation consisting of its
 :py:meth:`~MinimalRepOrc.presentation` on the nodes of the :any:`WordGraph`
 corresponds to a semigroup of size :py:meth:`~MinimalRepOrc.target_size`.
 
-If no such :py:meth:`~MinimalRepOrc.WordGraph` can be found, then an empty
-:py:meth:`~MinimalRepOrc.WordGraph` is returned (with ``0`` nodes and ``0``
-edges).
+If no such ::any:`WordGraph` can be found, then an empty :any:`WordGraph` is
+returned (with ``0`` nodes and ``0`` edges).
 )pbdoc");
 
     mro.def("__repr__", [](MinimalRepOrc const& mro) {
@@ -1585,7 +1584,7 @@ constructed from the presentation *p*.
 :raises LibsemigroupsError:  if *p* is not valid
 :raises LibsemigroupsError:  if *p* has 0-generators and 0-relations.
 
-.. seealso:: :py:meth:`~Sims1.presentation`
+.. seealso:: :py:meth:`~SimsRefinerIdeals.presentation`
 )pbdoc");
 
     sri.def(

--- a/src/todd-coxeter.cpp
+++ b/src/todd-coxeter.cpp
@@ -315,7 +315,7 @@ value is never :any:`UNDEFINED`.
             return todd_coxeter::current_word_of(self, i);
           },
           R"pbdoc(
-:sig=(i: int) -> list[int] | str:
+:sig=(self: ToddCoxeter, i: int) -> list[int] | str:
 
 Returns a current word representing a class with given index.
 
@@ -342,6 +342,7 @@ the root of that tree.
           },
           py::arg("i"),
           R"pbdoc(
+:sig=(self: ToddCoxeter, i: int) -> list[int] | str:
 Returns a word representing a class with given index.
 
 This function returns the word representing the class with index *i*. A
@@ -407,7 +408,7 @@ enumeration of ``tc``.)pbdoc",
           py::arg("p"),
           py::arg("t"),
           R"pbdoc(
-:sig=(p: Presentation, t: timedelta) -> tuple[list[int], list[int]] | tuple[str, str] | None:
+:sig=(p: Presentation, t: datetime.timedelta) -> tuple[list[int], list[int]] | tuple[str, str] | None:
 :only-document-once:
 
 Return a redundant rule or ``None``.
@@ -424,7 +425,7 @@ be shown to be redundant in this way, then ``None`` is returned.
 :type p: Presentation
 
 :param t: time to run Todd-Coxeter for every omitted rule.
-:type t: timedelta
+:type t: datetime.timedelta
 
 :returns: A redundant rule or ``None``.
 :rtype: tuple[list[int], list[int]] | tuple[str, str] | None
@@ -441,7 +442,7 @@ be shown to be redundant in this way, then ``None`` is returned.
             return {};
           },
           R"pbdoc(
-:sig=(p: Presentation, t: timedelta) -> tuple[list[int], list[int]] | tuple[str, str] | None:
+:sig=(p: Presentation, t: datetime.timedelta) -> tuple[list[int], list[int]] | tuple[str, str] | None:
 :only-document-once:
 )pbdoc");
 
@@ -520,7 +521,7 @@ full enumeration of *tc*.
             py::arg("try_for")   = std::chrono::milliseconds(100),
             py::arg("threshold") = 0.99,
             R"pbdoc(
-:sig=(tc: ToddCoxeter, tries: int, try_for: timedelta, threshold: float) -> tril:
+:sig=(tc: ToddCoxeter, tries: int, try_for: datetime.timedelta, threshold: float) -> tril:
 :only-document-once:
 
 Check if the congruence has more than one class.
@@ -553,7 +554,7 @@ non-trivial congruence containing the congruence represented by a
 :rtype: tril
  )pbdoc");
     }  // bind_todd_coxeter
-  }  // namespace
+  }    // namespace
 
   void init_todd_coxeter(py::module& m) {
     bind_todd_coxeter<word_type>(m, "ToddCoxeterWord");

--- a/src/word-graph.cpp
+++ b/src/word-graph.cpp
@@ -641,7 +641,7 @@ Adds a cycle consisting of *N* new nodes.
         [](WordGraph_ const& wg) { return word_graph::adjacency_matrix(wg); },
         py::arg("wg"),
         R"pbdoc(
-:sig=(wg: WordGraph) -> numpy.ndarray[numpy.float64[m, n]] | Matrix:
+:sig=(wg: WordGraph) -> numpy.ndarray[numpy.float64] | Matrix:
 Returns the adjacency matrix of a word graph.
 
 This function returns the adjacency matrix of the word graph *wg*. The
@@ -742,7 +742,7 @@ then :any:`UNDEFINED` is returned.
 :type from: int
 
 :param path: the path to follow.
-:type path: word_type
+:type path: list[int]
 
 :returns: The last node on the path or :any:`UNDEFINED`.
 :rtype: int | Undefined
@@ -1276,7 +1276,7 @@ order specified by *val*, and replaces the contents of the :any:`Forest`
 ``0``. The spanning tree corresponds to the order *val*.
 
 :param wg: the word graph.
-:type wg: Graph
+:type wg: WordGraph
 
 :param f: the Forest object to store the spanning tree.
 :type f: Forest

--- a/src/word-range.cpp
+++ b/src/word-range.cpp
@@ -658,7 +658,7 @@ Get the current value.
 Returns the current string in a :any:`StringRange` object.
 
 :returns: The current value.
-:rtype: str.
+:rtype: str
 )pbdoc");
     thing2.def(
         "init",
@@ -1222,10 +1222,10 @@ Returns a random string with the specified length over the specified alphabet.
 :type alphabet: str
 
 :param length: the length of the string.
-:type length: int.
+:type length: int
 
 :returns: A random string.
-:rtype: str.
+:rtype: str
 
 
 .. seealso::


### PR DESCRIPTION
This PR enables the Sphinx config option `nitpicky`, and addresses any resultant warnings. In `nitpicky` mode, Sphinx will warn about all references where the target cannot be found.

Additionally, this PR updates `conf.py`. Unused options have been removed, each setting has an explanation, and the options are ordered in the same way as they are in the sphinx documentation.