### PR TITLE
Fix subclass overrides and initialization order

### DIFF
--- a/docs/source/_ext/libsemigroups_pybind11_extensions.py
+++ b/docs/source/_ext/libsemigroups_pybind11_extensions.py
@@ -96,20 +96,10 @@ class ExtendedAutodocDirective(AutodocDirective):
 # replaced when the doc is built. It should be left empty.
 strings_replaced = set()
 
-# TODO(0): I think that, if we change the order in which we bind the functions
-# and class, it should be possible to remove the need for the following two type
-# replacement dictionaries.
-
 # This dictionary should be of the form "bad type" -> "good type", and
 # replacements will be performed globally. Hyperlinks will be added in the
 # signature if "good type" is a valid (potentially user defined) python type
 type_replacements = {
-    r"libsemigroups::WordGraph<unsigned int>": r"WordGraph",
-    r"libsemigroups::SimsStats": r"SimsStats",
-    r"libsemigroups::Sims1": r"Sims1",
-    r"libsemigroups::Sims2": r"Sims2",
-    r"libsemigroups::RepOrc": r"RepOrc",
-    r"libsemigroups::MinimalRepOrc": r"MinimalRepOrc",
     r"_?libsemigroups_pybind11\.": "",
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,13 +36,13 @@ namespace libsemigroups {
 #ifdef VERSION_INFO
     m.attr("__version__") = VERSION_INFO;
 #else
-    m.attr("__version__") = "dev";
+    m.attr("__version__")                   = "dev";
 #endif
 #ifdef LIBSEMIGROUPS_EIGEN_ENABLED
     m.attr("LIBSEMIGROUPS_EIGEN_ENABLED")
         = static_cast<bool>(LIBSEMIGROUPS_EIGEN_ENABLED);
 #else
-    m.attr("LIBSEMIGROUPS_EIGEN_ENABLED") = false;
+    m.attr("LIBSEMIGROUPS_EIGEN_ENABLED")   = false;
 #endif
 
 #ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED
@@ -52,14 +52,52 @@ namespace libsemigroups {
     m.attr("LIBSEMIGROUPS_HPCOMBI_ENABLED") = false;
 #endif
 
+    // At compile time, pybind11 tries to determine what the python type of a
+    // C++ object will be. This is used when determining what typehints should
+    // go in the doc, the contents of pybind11 error messsages, and may be used
+    // in function dispatch related ways (though JDE's not sure about that).
+    // Therefore, it is important that we try to init our classes in the order
+    // in which they are used.
+
+    // It seems as though the code still compiles if we don't manage to get the
+    // order perfect (but not always), and someties it is unavoidable to get the
+    // order "wrong" (e.g. some WordGraph helpers require Forest, and some
+    // Forest functions require WordGraph).
+
     ////////////////////////////////////////////////////////////////////////
     // Classes that need to be initialised early
     ////////////////////////////////////////////////////////////////////////
 
+    // Must be before most things
     init_constants(m);
+    init_order(m);
+    init_types(m);
+
+    // Must be before runners
     init_reporter(m);
     init_runner(m);
-    init_types(m);
+
+    // Must be before cong classes
+    init_present(m);
+    init_inverse_present(m);
+
+    // Must be before anything with visualisation
+    init_dot(m);
+
+    // Must be before WordGraph
+    init_forest(m);
+
+    // Must be before anything that returns or requires a WordGraph
+    init_word_graph(m);
+
+    // Must come before anything that uses elements
+    init_bmat8(m);
+    init_matrix(m);
+    init_pbr(m);
+    init_transf(m);
+
+    // Must come before paths
+    init_words(m);
 
     ////////////////////////////////////////////////////////////////////////
     // Classes in (almost) alphabetical order
@@ -74,11 +112,8 @@ namespace libsemigroups {
     init_aho_corasick(m);
     init_bipart(m);
     init_blocks(m);
-    init_bmat8(m);
     init_cong(m);
-    init_dot(m);
     init_error(m);
-    init_forest(m);
     init_freeband(m);
     init_froidure_pin_base(m);  // Must be before init_froidure_pin
     init_froidure_pin(m);
@@ -88,28 +123,25 @@ namespace libsemigroups {
     init_kbe(m);
     init_knuth_bendix(m);
     init_konieczny(m);
-    init_matrix(m);
     init_obvinf(m);
-    init_order(m);
     init_paths(m);
-    init_pbr(m);
-    init_present(m);
-    init_inverse_present(m);  // Must be after init_present
     init_presentation_examples(m);
     init_ranges(m);
     init_schreier_sims(m);
     init_sims(m);
     init_stephen(m);
+    init_todd_coxeter(m);
+    init_ukkonen(m);
+
+    ////////////////////////////////////////////////////////////////////////
+    // Classes that need to be initialised late
+    ////////////////////////////////////////////////////////////////////////
+
     init_to_congruence(m);
     init_to_froidure_pin(m);
     init_to_knuth_bendix(m);
     init_to_present(m);
     init_to_present(m);
     init_to_todd_coxeter(m);
-    init_todd_coxeter(m);
-    init_transf(m);
-    init_ukkonen(m);
-    init_word_graph(m);
-    init_words(m);
   }
 }  // namespace libsemigroups

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,15 +54,13 @@ namespace libsemigroups {
 
     // At compile time, pybind11 tries to determine what the python type of a
     // C++ object will be. This is used when determining what typehints should
-    // go in the doc, the contents of pybind11 error messsages, and may be used
+    // go in the doc, the contents of pybind11 error messages, and may be used
     // in function dispatch related ways (though JDE's not sure about that).
     // Therefore, it is important that we try to init our classes in the order
     // in which they are used.
 
     // It seems as though the code still compiles if we don't manage to get the
-    // order perfect (but not always), and someties it is unavoidable to get the
-    // order "wrong" (e.g. some WordGraph helpers require Forest, and some
-    // Forest functions require WordGraph).
+    // order perfect (but not always).
 
     ////////////////////////////////////////////////////////////////////////
     // Classes that need to be initialised early
@@ -80,7 +78,6 @@ namespace libsemigroups {
     // Must be before cong classes
     init_present(m);
     init_inverse_present(m);
-
     // Must be before anything with visualisation
     init_dot(m);
 

--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -45,15 +45,11 @@ namespace libsemigroups {
   // SimsSettings
   //////////////////////////////////////////////////////////////////////////////
 
+  // TODO(0): Decide if you can Construct from another object.
   template <typename Subclass>
-  void bind_sims(py::module&        m,
-                 std::string const& long_name,
-                 std::string_view   doc_type) {
+  void bind_sims_settings(py::class_<SimsSettings<Subclass>>& ss,
+                          std::string_view                    doc_type) {
     using SimsSettings_ = SimsSettings<Subclass>;
-
-    // There's no doc for SimsSettings itself only via inherited doc
-
-    py::class_<SimsSettings_> ss(m, long_name.c_str());
 
     ss.def(
         "number_of_threads",
@@ -1072,245 +1068,11 @@ Set all statistics to zero.
 )pbdoc");
 
     ////////////////////////////////////////////////////////////////////////////
-    // Sims1
-    ////////////////////////////////////////////////////////////////////////////
-
-    bind_sims<Sims1>(m, "SimsSettingsSims1", "Sims1");
-
-    py::class_<Sims1, SimsSettings<Sims1>> s1(m,
-                                              "Sims1",
-                                              R"pbdoc(
-For computing finite index right congruences of a finitely presented semigroup
-or monoid.
-
-The algorithm implemented by this class is essentially the low index subgroup
-algorithm for finitely presented groups described in Section 5.6 of
-:cite:`Sims1994aa`. The low index subgroups algorithm was adapted for
-semigroups and monoids by M. Anagnostopoulou-Merkouri, R. Cirpons, J. D.
-Mitchell, and M. Tsalakou; see :cite:`Anagnostopoulou-Merkouri2023aa`.
-
-The purpose of this class is to provide the functions
-:py:meth:`~Sims1.iterator`, :py:meth:`~Sims1.for_each` and
-:py:meth:`~Sims1.find_if`, which permit iterating through the one-sided
-congruences of a semigroup or monoid defined by a presentation containing (a
-possibly empty) set of pairs and with at most a given number of classes. An
-iterator returned by :py:meth:`~Sims1.iterator` yields :any:`WordGraph`
-instances representing the action of the semigroup or monoid on the classes of
-a congruence.
-
-.. seealso:: :any:`Sims2` for equivalent functionality for 2-sided congruences.
-)pbdoc");
-
-    def_sims_common(s1, "Sims1");
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Sims2
-    ////////////////////////////////////////////////////////////////////////////
-
-    bind_sims<Sims2>(m, "SimsSettingsSims2", "Sims2");
-
-    py::class_<Sims2, SimsSettings<Sims2>> s2(m,
-                                              "Sims2",
-                                              R"pbdoc(
-For computing finite index two-sided congruences of a finitely presented
-semigroup or monoid.
-
-The algorithm implemented by this class is described in
-:cite:`Anagnostopoulou-Merkouri2023aa`. The purpose of this class is to provide
-the functions :py:meth:`~Sims2.iterator`, :py:meth:`~Sims2.for_each` and
-:py:meth:`~Sims2.find_if`, which permit iterating through the two-sided
-congruences of a semigroup or monoid defined by a presentation containing, or
-not containing, (possibly empty) sets of pairs and with at most a given number
-of classes. An iterator returned by :py:meth:`~Sims2.iterator` yields
-:any:`WordGraph` instances representing the action of the semigroup or monoid
-on the classes of a congruence.
-
-.. seealso::
-    :any:`Sims1` for equivalent functionality for 1-sided congruences.
-)pbdoc");
-
-    def_sims_common(s2, "Sims2");
-
-    ////////////////////////////////////////////////////////////////////////////
-    // RepOrc
-    ////////////////////////////////////////////////////////////////////////////
-
-    bind_sims<RepOrc>(m, "SimsSettingsRepOrc", "RepOrc");
-
-    py::class_<RepOrc, SimsSettings<RepOrc>> ro(m,
-                                                "RepOrc",
-                                                R"pbdoc(
-For computing small degree transformation representations of a finite
-semigroup or monoid.
-
-This class is a helper for :any:`Sims1` calling the :any:`word_graph` member
-function attempts to find a right congruence, represented as an
-:any:`WordGraph`, of the semigroup or monoid defined by the presentation
-consisting of its :py:meth:`~RepOrc.presentation` and
-:py:meth:`~RepOrc.long_rules` with the following properties:
-
-* the transformation semigroup defined by the :any:`WordGraph` has size
-  :py:meth:`~RepOrc.target_size` ;
-* the number of nodes in the :any:`WordGraph` is at least
-  :py:meth:`~RepOrc.min_nodes` and at most :py:meth:`~RepOrc.max_nodes`.
-
-If no such :any:`WordGraph` can be found, then an empty :any:`WordGraph` is
-returned (with ``0`` nodes and ``0`` edges).
-)pbdoc");
-
-    def_reporc_common(ro, "RepOrc");
-
-    ro.def(
-        "max_nodes",
-        [](RepOrc const& self) { return self.max_nodes(); },
-        R"pbdoc(
-Get the current maximum number of nodes.
-
-This function returns the current value for the maximum number of nodes in the
-:any:`WordGraph` that we are seeking.
-
-:returns: A value of type ``int``.
-:rtype: int
-)pbdoc");
-
-    ro.def(
-        "max_nodes",
-        [](RepOrc& self, size_t val) -> RepOrc& { return self.max_nodes(val); },
-        py::arg("val"),
-        R"pbdoc(
-:sig=(self: RepOrc, val: int) -> RepOrc:
-
-Set the maximum number of nodes.
-
-This function sets the maximum number of nodes in the :any:`WordGraph` that we
-are seeking.
-
-:param val: the maximum number of nodes
-:type val: int
-
-:returns: The first argument *self*.
-:rtype: RepOrc
-)pbdoc");
-
-    ro.def(
-        "min_nodes",
-        [](RepOrc const& self) { return self.min_nodes(); },
-        R"pbdoc(
-Get the current minimum number of nodes.
-
-This function returns the current value for the minimum number of nodes in the
-:any:`WordGraph` that we are seeking.
-
-:returns: A value of type ``int``.
-:rtype: int
-)pbdoc");
-
-    ro.def(
-        "min_nodes",
-        [](RepOrc& self, size_t val) -> RepOrc& { return self.min_nodes(val); },
-        py::arg("val"),
-        R"pbdoc(
-:sig=(self: RepOrc, val: int) -> RepOrc:
-
-Set the minimum number of nodes.
-
-This function sets the minimal number of nodes in the :any:`WordGraph` that we
-are seeking.
-
-:param val: the minimum number of nodes
-:type val: int
-
-:returns: The first argument *self*.
-:rtype: RepOrc
-)pbdoc");
-
-    // The next function returns by value, so no return_value_policy required
-    // here.
-    ro.def("word_graph",
-           &RepOrc::word_graph,
-           R"pbdoc(
-Get the word graph.
-
-This function attempts to find a right congruence, represented as an
-:any:`WordGraph`, of the semigroup or monoid defined by the presentation
-consisting of its :py:meth:`~RepOrc.presentation` and
-:py:meth`~RepOrc.long_rules` with the following properties:
-
-* the transformation semigroup defined by the :any:`WordGraph` has size
-  :py:meth:`~RepOrc.target_size` ;
-* the number of nodes in the :any:`WordGraph` is at least
-  :py:meth:`~RepOrc.min_nodes` and at most :py:meth:`~RepOrc.max_nodes`.
-
-If no such :any:`WordGraph` can be found, then an empty :any:`WordGraph` is
-returned (with ``0`` nodes and ``0`` edges).
-
-:returns: A value of type :any:`WordGraph`.
-:rtype: WordGraph
-)pbdoc");
-
-    ////////////////////////////////////////////////////////////////////////////
-    // MinimalRepOrc
-    ////////////////////////////////////////////////////////////////////////////
-
-    bind_sims<MinimalRepOrc>(m, "SimsSettingsMinimalRepOrc", "MinimalRepOrc");
-
-    py::class_<MinimalRepOrc, SimsSettings<MinimalRepOrc>> mro(m,
-                                                               "MinimalRepOrc",
-                                                               R"pbdoc(
-For computing the minimal degree of a transformation representation arising
-from a right congruence of a finite semigroup or monoid.
-
-This class is a helper for :any:`Sims1`, calling the :any:`word_graph` member
-function attempts to find a right congruence, represented as an
-:any:`WordGraph`, with the minimum possible number of nodes such that the
-action of the semigroup or monoid defined by the presentation consisting of its
-:py:meth:`~MinimalRepOrc.presentation` on the nodes of the :any:`WordGraph`
-corresponds to a semigroup of size :py:meth:`~MinimalRepOrc.target_size`.
-
-If no such ::any:`WordGraph` can be found, then an empty :any:`WordGraph` is
-returned (with ``0`` nodes and ``0`` edges).
-)pbdoc");
-
-    def_reporc_common(mro, "MinimalRepOrc");
-
-    // The next function returns by value, so no return_value_policy required
-    // here.
-    mro.def("word_graph",
-            &MinimalRepOrc::word_graph,
-            R"pbdoc(
-Get the word graph.
-
-This function attempts to find a right congruence, represented as an
-:any:`WordGraph`, with the minimum possible number of nodes such that the
-action of the semigroup or monoid defined by the presentation consisting of its
-:py:meth:`~MinimalRepOrc.presentation` and :py:meth:`~MinimalRepOrc.long_rules`
-on the nodes of the :any:`WordGraph` corresponds to a semigroup of size
-:py:meth:`~MinimalRepOrc.target_size`. If no such :any:`WordGraph` can be
-found, then an empty :any:`WordGraph` is returned (with ``0`` nodes and ``0``
-edges).
-
-The algorithm implemented by this function repeatedly runs:
-
-.. code-block:: python3
-
-    RepOrc(self)
-        .min_nodes(1)
-        .max_nodes(best)
-        .target_size(self.target_size())
-        .word_graph();
-
-
-where ``best`` is initially :py:meth:`~MinimalRepOrc.target_size`, until the
-returned :any:`WordGraph` is empty, and then the penultimate :any:`WordGraph`
-is returned (if any).
-
-:returns: A value of type :any:`WordGraph`.
-:rtype: WordGraph
-)pbdoc");
-
-    ////////////////////////////////////////////////////////////////////////////
     // SimsRefinerFaithful
     ////////////////////////////////////////////////////////////////////////////
+
+    // The refiners are defined before Sims because the refiners appear as
+    // parameters types or return types for later functions.
 
     py::class_<SimsRefinerFaithful> srf(m,
                                         "SimsRefinerFaithful",
@@ -1559,6 +1321,237 @@ will result in a word graph defining a Rees congruence. Otherwise returns
 :returns: A boolean.
 :rtype: bool
 )pbdoc");
+
+    ////////////////////////////////////////////////////////////////////////////
+    // RepOrc
+    ////////////////////////////////////////////////////////////////////////////
+    py::class_<SimsSettings<RepOrc>>         ssro(m, "SimsSettingsRepOrc");
+    py::class_<RepOrc, SimsSettings<RepOrc>> ro(m, "RepOrc", R"pbdoc(
+For computing small degree transformation representations of a finite
+semigroup or monoid.
+
+This class is a helper for :any:`Sims1` calling the :any:`word_graph` member
+function attempts to find a right congruence, represented as an
+:any:`WordGraph`, of the semigroup or monoid defined by the presentation
+consisting of its :py:meth:`~RepOrc.presentation` and
+:py:meth:`~RepOrc.long_rules` with the following properties:
+
+* the transformation semigroup defined by the :any:`WordGraph` has size
+  :py:meth:`~RepOrc.target_size` ;
+* the number of nodes in the :any:`WordGraph` is at least
+  :py:meth:`~RepOrc.min_nodes` and at most :py:meth:`~RepOrc.max_nodes`.
+
+If no such :any:`WordGraph` can be found, then an empty :any:`WordGraph` is
+returned (with ``0`` nodes and ``0`` edges).
+)pbdoc");
+
+    bind_sims_settings(ssro, "RepOrc");
+    def_reporc_common(ro, "RepOrc");
+
+    ro.def(
+        "max_nodes",
+        [](RepOrc const& self) { return self.max_nodes(); },
+        R"pbdoc(
+Get the current maximum number of nodes.
+
+This function returns the current value for the maximum number of nodes in the
+:any:`WordGraph` that we are seeking.
+
+:returns: A value of type ``int``.
+:rtype: int
+)pbdoc");
+
+    ro.def(
+        "max_nodes",
+        [](RepOrc& self, size_t val) -> RepOrc& { return self.max_nodes(val); },
+        py::arg("val"),
+        R"pbdoc(
+:sig=(self: RepOrc, val: int) -> RepOrc:
+
+Set the maximum number of nodes.
+
+This function sets the maximum number of nodes in the :any:`WordGraph` that we
+are seeking.
+
+:param val: the maximum number of nodes
+:type val: int
+
+:returns: The first argument *self*.
+:rtype: RepOrc
+)pbdoc");
+
+    ro.def(
+        "min_nodes",
+        [](RepOrc const& self) { return self.min_nodes(); },
+        R"pbdoc(
+Get the current minimum number of nodes.
+
+This function returns the current value for the minimum number of nodes in the
+:any:`WordGraph` that we are seeking.
+
+:returns: A value of type ``int``.
+:rtype: int
+)pbdoc");
+
+    ro.def(
+        "min_nodes",
+        [](RepOrc& self, size_t val) -> RepOrc& { return self.min_nodes(val); },
+        py::arg("val"),
+        R"pbdoc(
+:sig=(self: RepOrc, val: int) -> RepOrc:
+
+Set the minimum number of nodes.
+
+This function sets the minimal number of nodes in the :any:`WordGraph` that we
+are seeking.
+
+:param val: the minimum number of nodes
+:type val: int
+
+:returns: The first argument *self*.
+:rtype: RepOrc
+)pbdoc");
+
+    // The next function returns by value, so no return_value_policy required
+    // here.
+    ro.def("word_graph",
+           &RepOrc::word_graph,
+           R"pbdoc(
+Get the word graph.
+
+This function attempts to find a right congruence, represented as an
+:any:`WordGraph`, of the semigroup or monoid defined by the presentation
+consisting of its :py:meth:`~RepOrc.presentation` and
+:py:meth`~RepOrc.long_rules` with the following properties:
+
+* the transformation semigroup defined by the :any:`WordGraph` has size
+  :py:meth:`~RepOrc.target_size` ;
+* the number of nodes in the :any:`WordGraph` is at least
+  :py:meth:`~RepOrc.min_nodes` and at most :py:meth:`~RepOrc.max_nodes`.
+
+If no such :any:`WordGraph` can be found, then an empty :any:`WordGraph` is
+returned (with ``0`` nodes and ``0`` edges).
+
+:returns: A value of type :any:`WordGraph`.
+:rtype: WordGraph
+)pbdoc");
+
+    ////////////////////////////////////////////////////////////////////////////
+    // MinimalRepOrc
+    ////////////////////////////////////////////////////////////////////////////
+
+    py::class_<SimsSettings<MinimalRepOrc>> ssmro(m,
+                                                  "SimsSettingsMinimalRepOrc");
+
+    py::class_<MinimalRepOrc, SimsSettings<MinimalRepOrc>> mro(
+        m, "MinimalRepOrc", R"pbdoc(
+For computing the minimal degree of a transformation representation arising
+from a right congruence of a finite semigroup or monoid.
+
+This class is a helper for :any:`Sims1`, calling the :any:`word_graph` member
+function attempts to find a right congruence, represented as an
+:any:`WordGraph`, with the minimum possible number of nodes such that the
+action of the semigroup or monoid defined by the presentation consisting of its
+:py:meth:`~MinimalRepOrc.presentation` on the nodes of the :any:`WordGraph`
+corresponds to a semigroup of size :py:meth:`~MinimalRepOrc.target_size`.
+
+If no such ::any:`WordGraph` can be found, then an empty :any:`WordGraph` is
+returned (with ``0`` nodes and ``0`` edges).
+)pbdoc");
+
+    bind_sims_settings(ssmro, "MinimalRepOrc");
+    def_reporc_common(mro, "MinimalRepOrc");
+
+    // The next function returns by value, so no return_value_policy required
+    // here.
+    mro.def("word_graph",
+            &MinimalRepOrc::word_graph,
+            R"pbdoc(
+Get the word graph.
+
+This function attempts to find a right congruence, represented as an
+:any:`WordGraph`, with the minimum possible number of nodes such that the
+action of the semigroup or monoid defined by the presentation consisting of its
+:py:meth:`~MinimalRepOrc.presentation` and :py:meth:`~MinimalRepOrc.long_rules`
+on the nodes of the :any:`WordGraph` corresponds to a semigroup of size
+:py:meth:`~MinimalRepOrc.target_size`. If no such :any:`WordGraph` can be
+found, then an empty :any:`WordGraph` is returned (with ``0`` nodes and ``0``
+edges).
+
+The algorithm implemented by this function repeatedly runs:
+
+.. code-block:: python3
+
+    RepOrc(self)
+        .min_nodes(1)
+        .max_nodes(best)
+        .target_size(self.target_size())
+        .word_graph();
+
+
+where ``best`` is initially :py:meth:`~MinimalRepOrc.target_size`, until the
+returned :any:`WordGraph` is empty, and then the penultimate :any:`WordGraph`
+is returned (if any).
+
+:returns: A value of type :any:`WordGraph`.
+:rtype: WordGraph
+)pbdoc");
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Sims1
+    ////////////////////////////////////////////////////////////////////////////
+
+    py::class_<SimsSettings<Sims1>>        sss1(m, "SimsSettingsSims1");
+    py::class_<Sims1, SimsSettings<Sims1>> s1(m, "Sims1", R"pbdoc(
+For computing finite index right congruences of a finitely presented semigroup
+or monoid.
+
+The algorithm implemented by this class is essentially the low index subgroup
+algorithm for finitely presented groups described in Section 5.6 of
+:cite:`Sims1994aa`. The low index subgroups algorithm was adapted for
+semigroups and monoids by M. Anagnostopoulou-Merkouri, R. Cirpons, J. D.
+Mitchell, and M. Tsalakou; see :cite:`Anagnostopoulou-Merkouri2023aa`.
+
+The purpose of this class is to provide the functions
+:py:meth:`~Sims1.iterator`, :py:meth:`~Sims1.for_each` and
+:py:meth:`~Sims1.find_if`, which permit iterating through the one-sided
+congruences of a semigroup or monoid defined by a presentation containing (a
+possibly empty) set of pairs and with at most a given number of classes. An
+iterator returned by :py:meth:`~Sims1.iterator` yields :any:`WordGraph`
+instances representing the action of the semigroup or monoid on the classes of
+a congruence.
+
+.. seealso:: :any:`Sims2` for equivalent functionality for 2-sided congruences.
+)pbdoc");
+
+    bind_sims_settings(sss1, "Sims1");
+    def_sims_common(s1, "Sims1");
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Sims2
+    ////////////////////////////////////////////////////////////////////////////
+
+    py::class_<SimsSettings<Sims2>>        sss2(m, "SimsSettingsSims2");
+    py::class_<Sims2, SimsSettings<Sims2>> s2(m, "Sims2", R"pbdoc(
+For computing finite index two-sided congruences of a finitely presented
+semigroup or monoid.
+
+The algorithm implemented by this class is described in
+:cite:`Anagnostopoulou-Merkouri2023aa`. The purpose of this class is to provide
+the functions :py:meth:`~Sims2.iterator`, :py:meth:`~Sims2.for_each` and
+:py:meth:`~Sims2.find_if`, which permit iterating through the two-sided
+congruences of a semigroup or monoid defined by a presentation containing, or
+not containing, (possibly empty) sets of pairs and with at most a given number
+of classes. An iterator returned by :py:meth:`~Sims2.iterator` yields
+:any:`WordGraph` instances representing the action of the semigroup or monoid
+on the classes of a congruence.
+
+.. seealso::
+    :any:`Sims1` for equivalent functionality for 1-sided congruences.
+)pbdoc");
+
+    bind_sims_settings(sss2, "Sims2");
+    def_sims_common(s2, "Sims2");
 
     ////////////////////////////////////////////////////////////////////////////
     // Helper functions

--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -597,6 +597,9 @@ Reinitialize an existing :any:`{0}` object.
 This function re-initializes a :any:`{0}` instance to be in the same state as
 *that*.
 
+:param that: The instance use for reinitialization.
+:type that: {0}
+
 :returns: The re-initialized object.
 :rtype: {0}
 )pbdoc",

--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -45,7 +45,6 @@ namespace libsemigroups {
   // SimsSettings
   //////////////////////////////////////////////////////////////////////////////
 
-  // TODO(0): Decide if you can Construct from another object.
   template <typename Subclass>
   void bind_sims_settings(py::class_<SimsSettings<Subclass>>& ss,
                           std::string_view                    doc_type) {
@@ -563,12 +562,13 @@ words of type specified by *word*.
                           doc_type)
                   .c_str());
 
-    thing.def(py::init<Thing const&>(),
-              fmt::format(R"pbdoc(
-Construct from a {0} object.
-)pbdoc",
-                          doc_type)
-                  .c_str());
+    // TODO(0): Uncomment or remove
+    // thing.def(py::init<Thing const&>(),
+    //           fmt::format(R"pbdoc(
+    // Construct from a {0} object.
+    // )pbdoc",
+    //                       doc_type)
+    //               .c_str());
 
     thing.def(
         "init",
@@ -1071,8 +1071,9 @@ Set all statistics to zero.
     // SimsRefinerFaithful
     ////////////////////////////////////////////////////////////////////////////
 
-    // The refiners are defined before Sims because the refiners appear as
-    // parameters types or return types for later functions.
+    // The refiners are defined before Sims because the
+    // refiners appear as parameters types or return types
+    // for later functions.
 
     py::class_<SimsRefinerFaithful> srf(m,
                                         "SimsRefinerFaithful",
@@ -1130,7 +1131,8 @@ must be checked by some other means.
 :type forbid: list[list[int]]
 )pbdoc");
 
-    // Despite what's written here this does not return by reference for JDM
+    // Despite what's written here this does not return by
+    // reference for JDM
     srf.def(
         "forbid",
         [](SimsRefinerFaithful const& srf) -> auto const& {
@@ -1235,7 +1237,8 @@ words of type specified by *word*.
 :Keyword Arguments:
     * **word** (*type*) -- the type of words to use, must be ``list[int]``.
 )pbdoc");
-    sri.def(py::init<Presentation<word_type> const&>(), R"pbdoc(
+    sri.def(py::init<Presentation<word_type> const&>(),
+            R"pbdoc(
 :sig=(self: SimsRefinerIdeals, p: Presentation) -> None:
 
 Construct from presentation.
@@ -1412,8 +1415,8 @@ are seeking.
 :rtype: RepOrc
 )pbdoc");
 
-    // The next function returns by value, so no return_value_policy required
-    // here.
+    // The next function returns by value, so no
+    // return_value_policy required here.
     ro.def("word_graph",
            &RepOrc::word_graph,
            R"pbdoc(
@@ -1462,8 +1465,8 @@ returned (with ``0`` nodes and ``0`` edges).
     bind_sims_settings(ssmro, "MinimalRepOrc");
     def_reporc_common(mro, "MinimalRepOrc");
 
-    // The next function returns by value, so no return_value_policy required
-    // here.
+    // The next function returns by value, so no
+    // return_value_policy required here.
     mro.def("word_graph",
             &MinimalRepOrc::word_graph,
             R"pbdoc(


### PR DESCRIPTION
This PR does two things:
1. Refactor the sims binding code so that subclasses do not incorrectly override (rather than overload) certain functions (addressing #305) ; and
2. Change the order in which things are initialized. This reduces the amount of C++ style code that appears in the error messages, amongst other places.