### PR TITLE
Update dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dev = [
     "gevent==25.5.1",
     "graphviz==0.20.3",
     "greenlet==3.2.3",
-    "numpy==2.0.2",
+    "numpy==2.3.2",
     "ox_profile==0.2.14",
     "packaging==24.2",
     "pexpect==4.9.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ exceptiongroup==1.3.0
 gevent==25.5.1
 graphviz==0.20.3
 greenlet==3.2.3
-numpy==2.0.2
+numpy==2.0.2;python_version<="3.12"
+numpy==2.3.2;python_version>="3.13"
 ox_profile==0.2.14
 packaging==24.2
 pexpect==4.9.0


### PR DESCRIPTION
This PR changes the required version of Numpy to be 2.3.2 for versions of Python greater than or equal to 3.13. 