### PR TITLE
Add CI workflow that tests using conda `libsemigroups`

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,7 +32,6 @@ jobs:
           environment-name: libsemigroups
           create-args: >-
             python
-            fmt
       - name: "Set environment variables . . ."
         run: |
           echo "PKG_CONFIG_PATH=$MAMBA_ROOT_PREFIX/envs/libsemigroups/lib/pkgconfig:$MAMBA_ROOT_PREFIX/envs/libsemigroups/share/pkgconfig:/usr/local/lib/pkgconfig" >> $GITHUB_ENV
@@ -50,7 +49,7 @@ jobs:
         run: |
           git clone --depth 1 --branch main https://github.com/libsemigroups/libsemigroups.git
           cd libsemigroups
-          ./autogen.sh && ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-hpcombi --with-external-fmt && sudo make install -j8
+          ./autogen.sh && ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-hpcombi && sudo make install -j8
           ccache -s
       - name: "Python version . . ."
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Run tests and lint
+name: Lint
 on: [pull_request, workflow_dispatch]
 
 concurrency:
@@ -7,11 +7,10 @@ concurrency:
 
 jobs:
   run-tests:
-    name: ${{ matrix.os }} Python ${{ matrix.python_version }}
+    name: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macOS-latest]
         include:
           - os: ubuntu-latest
@@ -33,7 +32,7 @@ jobs:
         with:
           environment-name: libsemigroups
           create-args: >-
-            python=${{ matrix.python_version }}
+            python=3.13
             fmt
       - name: "Set environment variables . . ."
         run: |
@@ -65,13 +64,5 @@ jobs:
         run: |
           echo $PKG_CONFIG_PATH
           pip3 install . -v
-      - name: "python -m pytest -vv tests/test_*.py . . ."
-        run: |
-          python -m pytest -vv tests/test_*.py
-      - name: "Run doc tests . . ."
-        run: |
-          etc/make-doc.sh  # so that all files are generated!
-          cd docs
-          python -m sphinx -b doctest -d _build/doctrees source _build/doctest
       - name: "Running ruff, pylint and cpplint . . ."
         run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,6 @@ jobs:
           environment-name: libsemigroups
           create-args: >-
             python=3.13
-            fmt
       - name: "Set environment variables . . ."
         run: |
           echo "PKG_CONFIG_PATH=$MAMBA_ROOT_PREFIX/envs/libsemigroups/lib/pkgconfig:$MAMBA_ROOT_PREFIX/envs/libsemigroups/share/pkgconfig:/usr/local/lib/pkgconfig" >> $GITHUB_ENV
@@ -51,7 +50,7 @@ jobs:
         run: |
           git clone --depth 1 --branch main https://github.com/libsemigroups/libsemigroups.git
           cd libsemigroups
-          ./autogen.sh && ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-hpcombi --with-external-fmt && sudo make install -j8
+          ./autogen.sh && ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-hpcombi && sudo make install -j8
           ccache -s
       - name: "Python version . . ."
         run: |

--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -1,0 +1,60 @@
+name: Run tests (Conda libsemigroups)
+on: [pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-test:
+    name: ${{ matrix.os }}, Python ${{ matrix.python_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, macOS-latest]
+        include:
+          - os: ubuntu-latest
+            compiler: ccache g++
+          - os: macOS-latest
+            compiler: ccache clang++
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup ccache . . .
+        uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+          install_ccache: true
+      - name: Create micromamba environment . . .
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: libsemigroups
+          cache-environment: true
+          create-args: >-
+            python=${{ matrix.python_version }}
+            pip
+            libsemigroups
+      - name: Set environment variables . . .
+        run: |
+          echo "PKG_CONFIG_PATH=$MAMBA_ROOT_PREFIX/envs/libsemigroups/lib/pkgconfig:$MAMBA_ROOT_PREFIX/envs/libsemigroups/share/pkgconfig:/usr/local/lib/pkgconfig" >> $GITHUB_ENV
+          echo "PATH=$MAMBA_ROOT_PREFIX/envs/libsemigroups/bin:$PATH" >> $GITHUB_ENV
+      - name: Check Python version . . .
+        run: |
+          python --version
+          pip --version
+      - name: Install requirements . . .
+        run: pip install -r requirements.txt
+      - name: Pip install libsemigroups_pybind11 . . .
+        run: |
+          CXX="${{ matrix.compiler }}"  pip install . -v
+          ccache -s
+      - name: Run tests . . .
+        run: |
+          python -m pytest -vv tests/test_*.py
+      - name: Run doc tests . . .
+        run: |
+          etc/make-doc.sh  # so that all files are generated!
+          cd docs
+          python -m sphinx -b doctest -d _build/doctrees source _build/doctest

--- a/.github/workflows/test-github.yml
+++ b/.github/workflows/test-github.yml
@@ -1,0 +1,73 @@
+name: Run tests (GitHub libsemigroups)
+on: [pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-tests:
+    name: ${{ matrix.os }}, Python ${{ matrix.python_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, macOS-latest]
+        include:
+          - os: ubuntu-latest
+            compiler: g++
+          - os: macOS-latest
+            compiler: clang++
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      CXX: "ccache ${{ matrix.compiler }}"
+      CXXFLAGS: "-O2 -g"
+    steps:
+      - uses: actions/checkout@v5
+      - name: "Setup ccache . . ."
+        uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+          install_ccache: true
+      - name: "Create micromamba environment"
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: libsemigroups
+          create-args: >-
+            python=${{ matrix.python_version }}
+      - name: "Set environment variables . . ."
+        run: |
+          echo "PKG_CONFIG_PATH=$MAMBA_ROOT_PREFIX/envs/libsemigroups/lib/pkgconfig:$MAMBA_ROOT_PREFIX/envs/libsemigroups/share/pkgconfig:/usr/local/lib/pkgconfig" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$MAMBA_ROOT_PREFIX/envs/libsemigroups/lib:/usr/local/lib" >> $GITHUB_ENV
+          echo "PATH=$MAMBA_ROOT_PREFIX/envs/libsemigroups/bin:$PATH" >> $GITHUB_ENV
+      - name: "macOS only: Install libsemigroups dependencies . . ."
+        if: ${{ matrix.os == 'macOS-latest' }}
+        run: brew install autoconf automake libtool
+      - name: "Install libsemigroups . . ."
+        run: |
+          git clone --depth 1 --branch main https://github.com/libsemigroups/libsemigroups.git
+          cd libsemigroups
+          ./autogen.sh && ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-hpcombi && sudo make install -j8
+      - name: "Python version . . ."
+        run: |
+          python --version
+          pip3 --version
+      - name: "Pip installing requirements.txt . . ."
+        run: |
+          pip3 install -r requirements.txt
+      - name: "Pip3 installing libsemigroups_pybind11 . . ."
+        run: |
+          echo $PKG_CONFIG_PATH
+          pip3 install . -v
+      - name: "python -m pytest -vv tests/test_*.py . . ."
+        run: |
+          python -m pytest -vv tests/test_*.py
+      - name: "Run doc tests . . ."
+        run: |
+          etc/make-doc.sh  # so that all files are generated!
+          cd docs
+          python -m sphinx -b doctest -d _build/doctrees source _build/doctest


### PR DESCRIPTION
This PR adds a workflow that tests `libsemigroups_pybind11` against the conda version of `libsemigroups`. It also moves the linting into its own workflow.

Supersedes #240.