### PR TITLE
Test default values and `datetime` types

### DIFF
--- a/src/todd-coxeter-impl.cpp
+++ b/src/todd-coxeter-impl.cpp
@@ -969,6 +969,8 @@ lookaheads to be stopped early if the number of nodes being killed is too small
 want to stop the lookahead early, since lookaheads take some time but may not
 result in many nodes being killed).
 
+The default value is `0.01`
+
 :param val: the proportion of active nodes.
 :type val: float
 
@@ -1018,7 +1020,9 @@ The default value of this setting is ``options.lookahead_style.hlt``.
 )pbdoc");
     thing.def(
         "lower_bound",
-        [](ToddCoxeterImpl_ const& self) { return self.lower_bound(); },
+        [](ToddCoxeterImpl_ const& self) {
+          return from_int(self.lower_bound());
+        },
         R"pbdoc(
 :sig=(self: ToddCoxeter) -> int:
 
@@ -1120,7 +1124,7 @@ description of this setting.
 Specify the congruence enumeration strategy.
 
 The strategy used during the enumeration can be specified using this function.
-The default value is :any:`options.strategy`.
+The default value is :any:`options.strategy.hlt`.
 
 :param val: value indicating which strategy to use.
 :type val: ToddCoxeter.options.strategy

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2022-2024 J. D. Mitchell
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+"""
+This module contains some tests for the delta function.
+"""
+
+from datetime import datetime, timedelta
+from time import sleep
+
+from libsemigroups_pybind11 import delta
+
+
+def test_delta():
+    current_time = datetime.now()
+    wait_time = 10**-3
+    sleep(wait_time)
+    diff = delta(current_time)
+    assert isinstance(diff, timedelta)
+    assert diff > timedelta(seconds=wait_time)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -11,7 +11,7 @@ This module contains some tests for the libsemigroups_pybind11 functionality
 arising from runner.*pp in libsemigroups.
 """
 
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 from libsemigroups_pybind11 import Reporter, delta
 
@@ -20,14 +20,19 @@ def test_reporter_000():
     """
     Simple test case for the bindings of Reporter.
     """
+    creation_time = datetime.now()
     r = Reporter()
     assert not r.report()
     assert r.report_every() == timedelta(seconds=1)
     r.report_every(timedelta(seconds=2))
     assert r.report_every() == timedelta(seconds=2)
-    r.last_report()
+    assert isinstance(r.start_time(), datetime)
+    assert creation_time < r.start_time() < datetime.now()
+    assert isinstance(r.last_report(), datetime)
+    assert creation_time < r.last_report() < datetime.now()
+    reset_time = datetime.now()
     r.reset_last_report()
-    assert delta(r.last_report()) < timedelta(seconds=1)
+    assert reset_time < r.last_report() < datetime.now()
     r.report_prefix("Banana")
     assert r.report_prefix() == "Banana"
     r.init()

--- a/tests/test_todd_coxeter.py
+++ b/tests/test_todd_coxeter.py
@@ -30,6 +30,7 @@ from libsemigroups_pybind11 import (
     froidure_pin,
     WordRange,
     word_graph,
+    UNDEFINED,
 )
 
 from .cong_common import check_congruence_common_return_policy
@@ -145,6 +146,27 @@ def test_settings():
     p = Presentation([0])
     presentation.add_rule(p, [0, 0, 0, 0], [0, 0])
     tc = ToddCoxeter(congruence_kind.onesided, p)
+
+    # Check default values
+    assert tc.def_max() == 2000
+    assert tc.def_policy() == ToddCoxeter.options.def_policy.no_stack_if_no_space
+    assert tc.def_version() == ToddCoxeter.options.def_version.two
+    assert tc.f_defs() == 10**5
+    assert tc.hlt_defs() == 2 * 10**5
+    assert tc.large_collapse() == 10**5
+    assert tc.lookahead_extent() == ToddCoxeter.options.lookahead_extent.partial
+    assert tc.lookahead_growth_factor() == 2.0
+    assert tc.lookahead_growth_threshold() == 4
+    assert tc.lookahead_min() == 10**4
+    assert tc.lookahead_next() == 5 * 10**6
+    assert tc.lookahead_stop_early_interval() == timedelta(seconds=1)
+    assert abs(tc.lookahead_stop_early_ratio() - 0.01) < 10**-9
+    assert tc.lookahead_style() == ToddCoxeter.options.lookahead_style.hlt
+    assert tc.lower_bound() == UNDEFINED
+    assert not tc.save()
+    assert tc.strategy() == ToddCoxeter.options.strategy.hlt
+    assert not tc.use_relations_in_extra()
+
     # tc.reserve(10)
     tc.run()
 


### PR DESCRIPTION
This PR adds some tests of the default values of `ToddCoxeter` settings, and also the type of `datetime` object some functions return.