### PR TITLE
Sync presentation

### DIFF
--- a/docs/source/data-structures/presentations/present-helpers.rst
+++ b/docs/source/data-structures/presentations/present-helpers.rst
@@ -73,6 +73,7 @@ Contents
     strongly_compress
     throw_if_bad_inverses
     to_gap_string
+    try_detect_inverses
 
 Full API
 --------

--- a/src/libsemigroups_pybind11/presentation/__init__.py
+++ b/src/libsemigroups_pybind11/presentation/__init__.py
@@ -56,6 +56,7 @@ from _libsemigroups_pybind11 import (  # pylint: disable=no-name-in-module
     presentation_index_rule as _index_rule,
     presentation_is_normalized as _is_normalized,
     presentation_is_rule as _is_rule,
+    presentation_try_detect_inverses as _try_detect_inverses,
 )
 
 from libsemigroups_pybind11.detail.cxx_wrapper import (
@@ -274,3 +275,4 @@ add_cyclic_conjugates = _wrap_cxx_free_fn(_add_cyclic_conjugates)
 index_rule = _wrap_cxx_free_fn(_index_rule)
 is_normalized = _wrap_cxx_free_fn(_is_normalized)
 is_rule = _wrap_cxx_free_fn(_is_rule)
+try_detect_inverses = _wrap_cxx_free_fn(_try_detect_inverses)

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -1483,6 +1483,40 @@ and *rhs* is the next item in ``p.rules``.
   if :any:`Presentation.throw_if_bad_alphabet_or_rules` throws.
 )pbdoc");
 
+      m.def(
+          "presentation_try_detect_inverses",
+          [](Presentation<Word>& p) {
+            return presentation::try_detect_inverses(p);
+          },
+          py::arg("p"),
+          R"pbdoc(
+:sig=(p: Presentation) -> tuple[str | list[int], str | list[int]]:
+:only-document-once:
+
+Try to detect group inverses.
+
+This function tries to deduce group theoretic inverses defined by the rules of
+the presentation *p* as following: the rules of the presentation where one
+side has length 2 and the other has length 0 are detected. For any such rule we
+remember that the first letter is a possible inverse of the second. If rules of
+the form ``ab=1`` and ``ba=1`` are detected, then ``a`` has inverse ``b`` and
+vice versa. If there are multiple different such rules and we deduce
+conflicting values for the inverse of a letter, then an exception is
+raised.
+
+:param p: the presentation.
+:type p: Presentation
+
+:returns:
+  A tuple where the first item consists of letters such that an inverse was
+  detected; and the second item consists of the inverses such that the item in
+  position ``i`` is the inverse of the letter in position ``i``.
+:rtype: tuple[str | list[int], str | list[int]]
+
+:raises LibsemigroupsError:
+  if :any:`throw_if_bad_alphabet_or_rules` throws.
+:raises LibsemigroupsError:
+  if conflicting inverses for any letter are detected.)pbdoc");
     }  // bind_present
 
     template <typename Word>

--- a/tests/test_present.py
+++ b/tests/test_present.py
@@ -2224,3 +2224,14 @@ def test_presentation_is_rule():
     assert presentation.is_rule(p, "a" * 4, "")
     assert not presentation.is_rule(p, "", "a" * 4)
     assert not presentation.is_rule(p, "ad" * 4, "")
+
+
+def test_presentation_try_detect_inverses():
+    p = Presentation("abc")
+    p.contains_empty_word(True)
+    p.rules = ["aa", ""]
+
+    assert presentation.try_detect_inverses(p) == ("a", "a")
+    p.alphabet("abcdef")
+    p.rules = ["ab", "", "ba", "", "cd", "", "dc", "", "e", "ef"]
+    assert presentation.try_detect_inverses(p) == ("dcba", "cdab")


### PR DESCRIPTION
This PR adds support for 3 helper functions from `libsemigroups` that were not supported before. I think this means that all helper functions that we want to support from `presentation` are now supported.