### PR TITLE
Add to-table generation to make-doc.sh

### DIFF
--- a/docs/pictures/to-table.tex
+++ b/docs/pictures/to-table.tex
@@ -1,4 +1,4 @@
-\documentclass[png]{standalone}
+\documentclass{standalone}
 \usepackage{booktabs}  % For professional tables
 \usepackage{pifont}    % For check and cross symbols
 \usepackage{graphicx}  % For rotating text

--- a/etc/make-doc.sh
+++ b/etc/make-doc.sh
@@ -7,6 +7,23 @@ else
   PYTHON="python3"
 fi
 
+echo "Checking whether to build the to-table . . ."
+if command -v pdflatex && command -v inkscape 2>&1 >/dev/null; then
+  cd docs/pictures
+  echo "Building to-table . . ."
+  pdflatex to-table.tex
+  inkscape --pdf-poppler --export-type="svg" -o to-table.svg to-table.pdf
+  if [ $? -eq 0 ]; then
+    echo Successfully created to-table.svg
+  else
+    echo Warning: there was an issue with inkscape when creating to-table.svg
+    echo Please check the state of to-table.svg
+  fi
+  cd ../..
+else
+  echo "Not building to-table"
+fi
+
 $PYTHON etc/check-docstring-indentation.py
 
 cd docs/


### PR DESCRIPTION
This PR adds the automatic to-table generation from the libsemigroups [`make-doc.sh`](https://github.com/libsemigroups/libsemigroups/blob/main/etc/make-doc.sh) (credit: @Joseph-Edwards) to libsemigroups_pybind11. It will only run if pdflatex and inkscape are installed on your system (not in the build pipeline).

Also removes the unused [png] tag from the tex file. 