### PR TITLE
hpcombi: resolve #374

### DIFF
--- a/src/hpcombi.cpp
+++ b/src/hpcombi.cpp
@@ -569,7 +569,7 @@ The functionality described on this page is only available if
 
       thing.def(
           "__mul__",
-          // The next line is not a type, but is consistent with the
+          // The next line is not a typo, but is consistent with the
           // other transformations in libsemigroups_pybind11, since
           // function composition in HPCombi is backwards.
           [](PTransf16 const& x, PTransf16 const& y) { return y * x; },
@@ -1227,6 +1227,16 @@ The functionality described on this page is only available if
 
       thing.def("__copy__", [](Transf16 const& v) { return Transf16(v); });
 
+      thing.def(
+          "__mul__",
+          // The next line is not a typo, but is consistent with the
+          // other transformations in libsemigroups_pybind11, since
+          // function composition in HPCombi is backwards.
+          // Also this method is required because the return type of the one for
+          // PTransf16 is always PTransf16.
+          [](Transf16 const& x, Transf16 const& y) { return y * x; },
+          py::is_operator());
+
       ////////////////////////////////////////////////////////////////////////
       // Constructors
       ////////////////////////////////////////////////////////////////////////
@@ -1414,6 +1424,16 @@ The functionality described on this page is only available if
 
       thing.def("__repr__",
                 [](Perm16 const& self) { return repr(self, "Perm16"); });
+
+      thing.def(
+          "__mul__",
+          // The next line is not a typo, but is consistent with the
+          // other transformations in libsemigroups_pybind11, since
+          // function composition in HPCombi is backwards.
+          // Also this method is required because the return type of the one for
+          // PTransf16 is always PTransf16.
+          [](Perm16 const& x, Perm16 const& y) { return y * x; },
+          py::is_operator());
 
       ////////////////////////////////////////////////////////////////////////
       // Static methods
@@ -2156,6 +2176,16 @@ The functionality described on this page is only available if
         throw pybind11::type_error("unsupported operand type(s) ** or pow(): "
                                    "'PPerm16' and 'int");
       });
+
+      thing.def(
+          "__mul__",
+          // The next line is not a typo, but is consistent with the
+          // other transformations in libsemigroups_pybind11, since
+          // function composition in HPCombi is backwards.
+          // Also this method is required because the return type of the one for
+          // PTransf16 is always PTransf16.
+          [](PPerm16 const& x, PPerm16 const& y) { return y * x; },
+          py::is_operator());
 
       ////////////////////////////////////////////////////////////////////////
       // Static methods

--- a/tests/test_hpcombi.py
+++ b/tests/test_hpcombi.py
@@ -306,6 +306,10 @@ if LIBSEMIGROUPS_HPCOMBI_ENABLED:
         assert PTransf16([1, 3, 2, 255, 10]).nb_fix_points() == 12
         assert PTransf16.one().nb_fix_points() == 16
 
+    def test_hpcombi_ptransf_mul_return_type():
+        x = PTransf16([1, 3, 2, 255, 10])
+        assert isinstance(x * x, PTransf16)
+
     ########################################################################
     # Transf16
     ########################################################################
@@ -360,6 +364,10 @@ if LIBSEMIGROUPS_HPCOMBI_ENABLED:
     def test_hpcombi_transf16_one():
         assert Transf16.one() == Transf16(list(range(16)))
         assert isinstance(Transf16.one(), Transf16)
+
+    def test_hpcombi_transf_mul_return_type():
+        x = Transf16([1, 0, 2])
+        assert isinstance(x * x, Transf16)
 
     ########################################################################
     # Perm16
@@ -497,6 +505,10 @@ if LIBSEMIGROUPS_HPCOMBI_ENABLED:
     def test_hpcombi_perm16_unrankSJT():  # pylint: disable=invalid-name
         assert Perm16.unrankSJT(2) == Perm16([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 13, 14])
 
+    def test_hpcombi_perm16_mul_return_type():
+        x = Perm16([1, 0, 2])
+        assert isinstance(x * x, Perm16)
+
     ########################################################################
     # PPerm16
     ########################################################################
@@ -561,3 +573,7 @@ if LIBSEMIGROUPS_HPCOMBI_ENABLED:
         assert x * x.inverse_ref() == x.left_one()
         assert x.inverse_ref() * x == x.right_one()
         assert x**-1 == x.inverse_ref()
+
+    def test_hpcombi_pperm16_mul_return_type():
+        x = PPerm16([1, 0, 2])
+        assert isinstance(x * x, PPerm16)


### PR DESCRIPTION
The return type of the product of any two hpcombi `PTransf16` objects, or any derived class, was always `PTransf16`. This commit resolves this issue.