### PR TITLE
presentation: attempt to resolve #391

### DIFF
--- a/src/libsemigroups_pybind11/presentation/__init__.py
+++ b/src/libsemigroups_pybind11/presentation/__init__.py
@@ -11,8 +11,10 @@ from typing_extensions import Self as _Self
 from _libsemigroups_pybind11 import (
     InversePresentationString as _InversePresentationString,
     InversePresentationWord as _InversePresentationWord,
+    RulesWord as _RulesWord,
     PresentationString as _PresentationString,
     PresentationWord as _PresentationWord,
+    RulesString as _RulesString,
     presentation_add_cyclic_conjugates as _add_cyclic_conjugates,
     presentation_add_identity_rules as _add_identity_rules,
     presentation_add_inverse_rules as _add_inverse_rules,
@@ -160,14 +162,23 @@ class Presentation(_CxxWrapper):
 
     @_copydoc(_PresentationWord.rules)
     @property
-    def rules(self: _Self) -> list[list[int] | str]:
+    def rules(self: _Self) -> list[list[int]] | list[str]:
         # pylint: disable=missing-function-docstring
         return _to_cxx(self).rules
 
     @rules.setter
-    def rules(self: _Self, val: list[list[int] | str]) -> None:
-        _to_cxx(self).rules = val
+    def rules(self: _Self, val: list[list[int]] | list[str]) -> None:
+        if self.py_template_params == (list[int],):
+            _to_cxx(self).rules = _RulesWord(val)
+        else:
+            _to_cxx(self).rules = _RulesString(val)
 
+
+# HACK: The next line is a hack to make _RulesString objects to look like
+# lists, for some reason _RulesWord doesn't have this problem. It looks like
+# _RulesString has a __repr__ function bound in pybind11::bind_vector and
+# defining it again has no effect.
+_RulesString.__repr__ = lambda self: repr(list(self))
 
 _copy_cxx_mem_fns(_PresentationWord, Presentation)
 _register_cxx_wrapped_type(_PresentationWord, Presentation)

--- a/src/libsemigroups_pybind11/presentation/__init__.py
+++ b/src/libsemigroups_pybind11/presentation/__init__.py
@@ -11,10 +11,10 @@ from typing_extensions import Self as _Self
 from _libsemigroups_pybind11 import (
     InversePresentationString as _InversePresentationString,
     InversePresentationWord as _InversePresentationWord,
-    RulesWord as _RulesWord,
     PresentationString as _PresentationString,
     PresentationWord as _PresentationWord,
     RulesString as _RulesString,
+    RulesWord as _RulesWord,
     presentation_add_cyclic_conjugates as _add_cyclic_conjugates,
     presentation_add_identity_rules as _add_identity_rules,
     presentation_add_inverse_rules as _add_inverse_rules,

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -1764,7 +1764,7 @@ defined in the alphabet, and that the inverses act as semigroup inverses.
       * :any:`presentation.throw_if_bad_inverses`
 )pbdoc");
     }  // bind_inverse_present
-  }  // namespace
+  }    // namespace
 
   void init_present(py::module& m) {
     bind_vector<word_type>(m, "RulesWord");

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -32,11 +32,7 @@
 #include <libsemigroups/word-range.hpp>    // for operator+
 
 // pybind11....
-#include <pybind11/cast.h>  // for arg
-
-PYBIND11_MAKE_OPAQUE(std::vector<std::string>);
-PYBIND11_MAKE_OPAQUE(std::vector<libsemigroups::word_type>);
-
+#include <pybind11/cast.h>           // for arg
 #include <pybind11/detail/common.h>  // for const_, overload_cast, ove...
 #include <pybind11/detail/descr.h>   // for operator+
 #include <pybind11/functional.h>     // for std::function conversion
@@ -47,6 +43,9 @@ PYBIND11_MAKE_OPAQUE(std::vector<libsemigroups::word_type>);
 
 // libsemigroups_pybind11....
 #include "main.hpp"  // for init_present
+
+PYBIND11_MAKE_OPAQUE(std::vector<std::string>);
+PYBIND11_MAKE_OPAQUE(std::vector<libsemigroups::word_type>);
 
 namespace libsemigroups {
   namespace py = pybind11;
@@ -1764,7 +1763,7 @@ defined in the alphabet, and that the inverses act as semigroup inverses.
       * :any:`presentation.throw_if_bad_inverses`
 )pbdoc");
     }  // bind_inverse_present
-  }    // namespace
+  }  // namespace
 
   void init_present(py::module& m) {
     bind_vector<word_type>(m, "RulesWord");

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -1763,7 +1763,7 @@ defined in the alphabet, and that the inverses act as semigroup inverses.
       * :any:`presentation.throw_if_bad_inverses`
 )pbdoc");
     }  // bind_inverse_present
-  }  // namespace
+  }    // namespace
 
   void init_present(py::module& m) {
     bind_vector<word_type>(m, "RulesWord");

--- a/src/transf.cpp
+++ b/src/transf.cpp
@@ -733,7 +733,7 @@ fewer points requiring less space per point.
       m.def("transf_inverse",
             py::overload_cast<Perm_ const&>(&inverse<N, Scalar>));
     }  // bind_perm
-  }  // namespace
+  }    // namespace
 
   void init_transf(py::module& m) {
     // Transformations


### PR DESCRIPTION
This resolves #391 by making `std::vector<word_type>` and `std::vector<std::string>` opaque types within `present.cpp` at least. The idea is that instead of such vectors being auto converted to lists, they are their own types. 

PROS: `p.rules` return a reference, (at least on my machine) the tests pass, and it's possible to do `p.rules[0] = something` and this actually works as expected. 

CONS: `p.rules` appears to be a `list`, but isn't, and so some things you might want to do with a `list` don't work (like `index` for example). This is a fairly large change.

I think the PROS out weigh the CONS, but happy to hear your opinion too @Joseph-Edwards 