### PR TITLE
Consistent constants

### DIFF
--- a/src/forest.cpp
+++ b/src/forest.cpp
@@ -76,7 +76,6 @@ Constructs a forest with *n* nodes, that is initialised so that the
                           parents,
                       std::vector<int_or_unsigned_constant<node_type>> const&
                           labels) {
-            using node_type = node_type;
             return make<Forest>(to_ints<node_type>(parents),
                                 to_ints<node_type>(labels));
           }),

--- a/src/forest.cpp
+++ b/src/forest.cpp
@@ -155,10 +155,7 @@ the same state as if it had just been constructed as ``Forest(n)``.
           "label",
           [](Forest const& self,
              node_type     i) -> int_or_unsigned_constant<node_type> {
-            if (self.label(i) != UNDEFINED) {
-              return {self.label(i)};
-            }
-            return {UNDEFINED};
+            return from_int(self.label(i));
           },
           py::arg("i"),
           R"pbdoc(

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -100,7 +100,7 @@ namespace libsemigroups {
                                              int_or_unsigned_constant<Int>>;
 
   template <typename Int>
-  Int to_int(int_or_constant<Int> val) {
+  Int to_int(int_or_constant<Int> const& val) {
     if (std::holds_alternative<Int>(val)) {
       return std::get<0>(val);
     } else if (std::holds_alternative<Undefined>(val)) {

--- a/src/transf.cpp
+++ b/src/transf.cpp
@@ -111,7 +111,11 @@ the image of the point ``i`` under the {0} is ``imgs[i]``.
             // corresponds to a std::out_of_range for things like list(a) to
             // work.
             try {
-              return from_int(a.at(b));
+              auto result = a.at(b);
+              if (result != UNDEFINED) {
+                return {result};
+              }
+              return {UNDEFINED};
             } catch (LibsemigroupsException const& e) {
               throw std::out_of_range(formatted_error_message(e));
             }
@@ -167,7 +171,10 @@ definition, which is equal to the size of :any:`{0}.images`.
             auto r = rx::iterator_range(self.begin(), self.end())
                      | rx::transform(
                          [](auto val) -> int_or_unsigned_constant<Scalar> {
-                           return from_int(val);
+                           if (val != UNDEFINED) {
+                             return {val};
+                           }
+                           return {UNDEFINED};
                          });
             return py::make_iterator(rx::begin(r), rx::end(r));
           },

--- a/src/transf.cpp
+++ b/src/transf.cpp
@@ -111,11 +111,7 @@ the image of the point ``i`` under the {0} is ``imgs[i]``.
             // corresponds to a std::out_of_range for things like list(a) to
             // work.
             try {
-              auto result = a.at(b);
-              if (result != UNDEFINED) {
-                return {result};
-              }
-              return {UNDEFINED};
+              return from_int(a.at(b));
             } catch (LibsemigroupsException const& e) {
               throw std::out_of_range(formatted_error_message(e));
             }
@@ -171,10 +167,7 @@ definition, which is equal to the size of :any:`{0}.images`.
             auto r = rx::iterator_range(self.begin(), self.end())
                      | rx::transform(
                          [](auto val) -> int_or_unsigned_constant<Scalar> {
-                           if (val != UNDEFINED) {
-                             return {val};
-                           }
-                           return {UNDEFINED};
+                           return from_int(val);
                          });
             return py::make_iterator(rx::begin(r), rx::end(r));
           },

--- a/src/transf.cpp
+++ b/src/transf.cpp
@@ -112,6 +112,8 @@ the image of the point ``i`` under the {0} is ``imgs[i]``.
             // work.
             try {
               auto result = a.at(b);
+              // Don't use from_int here, because that will incorrectly convert
+              // things to LIMIT_MAX and POSITIVE_INFINITY.
               if (result != UNDEFINED) {
                 return {result};
               }
@@ -170,6 +172,9 @@ definition, which is equal to the size of :any:`{0}.images`.
           [](PTransfSubclass& self) {
             auto r = rx::iterator_range(self.begin(), self.end())
                      | rx::transform(
+                         // Don't use from_int here, because that will
+                         // incorrectly convert things to LIMIT_MAX and
+                         // POSITIVE_INFINITY.
                          [](auto val) -> int_or_unsigned_constant<Scalar> {
                            if (val != UNDEFINED) {
                              return {val};


### PR DESCRIPTION
This PR includes some minor quality-of-life improvements such as removing redundant aliases, changing parameters to const-references, and using the `from_int` function more.