### PR TITLE
Add `to_ace_string`

### DIFF
--- a/docs/source/data-structures/presentations/present-helpers.rst
+++ b/docs/source/data-structures/presentations/present-helpers.rst
@@ -77,6 +77,7 @@ Contents
     sort_rules
     strongly_compress
     throw_if_bad_inverses
+    to_ace_string
     to_gap_string
     try_detect_inverses
 

--- a/src/libsemigroups_pybind11/presentation/__init__.py
+++ b/src/libsemigroups_pybind11/presentation/__init__.py
@@ -56,6 +56,7 @@ from _libsemigroups_pybind11 import (
     presentation_sort_rules as _sort_rules,
     presentation_strongly_compress as _strongly_compress,
     presentation_throw_if_bad_inverses as _throw_if_bad_inverses,
+    presentation_to_ace_string as _to_ace_string,
     presentation_to_gap_string as _to_gap_string,
     presentation_try_detect_inverses as _try_detect_inverses,
 )
@@ -272,6 +273,7 @@ sort_each_rule = _wrap_cxx_free_fn(_sort_each_rule)
 sort_rules = _wrap_cxx_free_fn(_sort_rules)
 strongly_compress = _wrap_cxx_free_fn(_strongly_compress)
 throw_if_bad_inverses = _wrap_cxx_free_fn(_throw_if_bad_inverses)
+to_ace_string = _wrap_cxx_free_fn(_to_ace_string)
 to_gap_string = _wrap_cxx_free_fn(_to_gap_string)
 balance = _wrap_cxx_free_fn(_balance)
 add_cyclic_conjugates = _wrap_cxx_free_fn(_add_cyclic_conjugates)
@@ -321,6 +323,7 @@ __all__ = [
     "sort_rules",
     "strongly_compress",
     "throw_if_bad_inverses",
+    "to_ace_string",
     "to_gap_string",
     "balance",
     "add_cyclic_conjugates",

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -1615,8 +1615,8 @@ are created by taking quotients of free semigroups or monoids.
 :only-document-once:
 Return the code that would create a presentation to be used with ACE.
 
-This function returns the string of ACE input that could be used to create an
-object with the same alphabet and rules as *p*.
+This function returns the string of ACE :cite:`Havas1999iy` input that could be
+used to create an object with the same alphabet and rules as *p*.
 
 :param p: the presentation.
 :type p: Presentation
@@ -1634,9 +1634,10 @@ object with the same alphabet and rules as *p*.
   ACE assumes that presentations are group presentations, where the the alphabet
   consists of lowercase letters, and inverses correspond to the equivalent
   uppercase letters. Therefore, a valid ACE presentation may not be a valid
-  libsemigroups presentation; for example, it is possible for relations in an
-  ACE presentation to contain uppercase letters that are not explicitly named as
-  generators, as long as their lowercase counterparts are listed as generators.
+  ``libsemigroups_pybdind11`` :any:`Presentation`; for example, it is possible
+  for relations in an ACE presentation to contain uppercase letters that are not
+  explicitly named as generators, as long as their lowercase counterparts are
+  listed as generators.
 )pbdoc");
       m.def(
           "presentation_throw_if_bad_inverses",

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -1613,7 +1613,7 @@ are created by taking quotients of free semigroups or monoids.
           R"pbdoc(
 :sig=(p: Presentation) -> str:
 :only-document-once:
-Return the code that would create a presentation to be used with ACE.
+Returns a string containing the content of an ACE input file.
 
 This function returns the string of ACE :cite:`Havas1999iy` input that could be
 used to create an object with the same alphabet and rules as *p*.

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -1607,6 +1607,38 @@ are created by taking quotients of free semigroups or monoids.
 :rtype: str
 )pbdoc");
       m.def(
+          "presentation_to_ace_string",
+          [](Presentation_ const& p) { return presentation::to_ace_string(p); },
+          py::arg("p"),
+          R"pbdoc(
+:sig=(p: Presentation) -> str:
+:only-document-once:
+Return the code that would create a presentation to be used with ACE.
+
+This function returns the string of ACE input that could be used to create an
+object with the same alphabet and rules as *p*.
+
+:param p: the presentation.
+:type p: Presentation
+
+:returns: The ACE string.
+:rtype: str
+
+:raises LibsemigroupsError: if ``p.alphabet()`` contains any duplicate letters.
+:raises LibsemigroupsError: if any of the letters in the alphabet of
+  *p* are not lowercase, or do not correspond to a lowercase letter when
+  transformed to a string using :any:`words.human_readable_letter`.
+
+.. note::
+
+  ACE assumes that presentations are group presentations, where the the alphabet
+  consists of lowercase letters, and inverses correspond to the equivalent
+  uppercase letters. Therefore, a valid ACE presentation may not be a valid
+  libsemigroups presentation; for example, it is possible for relations in an
+  ACE presentation to contain uppercase letters that are not explicitly named as
+  generators, as long as their lowercase counterparts are listed as generators.
+)pbdoc");
+      m.def(
           "presentation_throw_if_bad_inverses",
           [](Presentation_ const& p, Word const& inverses) {
             presentation::throw_if_bad_inverses(p, inverses);

--- a/tests/test_present.py
+++ b/tests/test_present.py
@@ -803,6 +803,22 @@ def check_remove_generator(conversion_function):
         p.remove_generator(letter(11))
 
 
+def check_to_ace_string(W):
+    p = Presentation(W([0, 1]))
+    p.contains_empty_word(True)
+    presentation.add_rule(p, W([0, 0]), W([]))
+    presentation.add_rule(p, W([1, 1, 1]), W([]))
+    presentation.add_rule(p, W([0, 1, 0, 1]), W([]))
+    assert (
+        presentation.to_ace_string(p)
+        == """Group: a, b;
+wo: 4g; # workspace size, adjust as necessary
+Rel: aa, bbb, abab;
+Mess: 100000; # message frequency, adjust as necessary
+End;"""
+    )
+
+
 ###############################################################################
 # Test functions begin
 ###############################################################################
@@ -1759,3 +1775,8 @@ def test_add_involution_rules():
 def test_add_idempotent_rules():
     check_add_idempotent_rules(to_word)
     check_add_idempotent_rules(to_string)
+
+
+def test_to_ace_string():
+    check_to_ace_string(to_word)
+    check_to_ace_string(to_string)


### PR DESCRIPTION
This PR adds a function that can convert a presentation into ACE input. I am not 100% happy with the documentation here, because the function behaves differently (specifically, throws errors in different circumstances) dependent on whether it is called on a presentation over strings or words. I've tried to give a general idea of what might happen, but I'm keen to hear any suggestions on how to make it better. Should I be more verbose about what happens in the two cases, or is it fine as it is?