### PR TITLE
Update output relating to RPO

### DIFF
--- a/tests/test_knuth_bendix.py
+++ b/tests/test_knuth_bendix.py
@@ -344,7 +344,7 @@ def test_rpo():
 
     kb = KnuthBendix(congruence_kind.twosided, p, order=Order.rpo)
     kb.run()
-    assert list(kb.active_rules()) == [("bbb", ""), ("aa", ""), ("abb", "baba"), ("abab", "bba")]
+    assert list(kb.active_rules()) == [("bbb", ""), ("aa", ""), ("bba", "abab"), ("baba", "abb")]
 
 
 # TODO(0) Does the alphabet bug persist? YES: the test fails


### PR DESCRIPTION
In https://github.com/libsemigroups/libsemigroups/pull/1035, we swapped the meaning of `rpo` and `rev_rpo` for so that these orders are special cases of `wr_order` and `rev_wr_order` respectively. In this PR, we change the test output to match the new order behaviour.