### PR TITLE
Fix InversePresentation keyword argument forwarding

### DIFF
--- a/src/libsemigroups_pybind11/presentation/__init__.py
+++ b/src/libsemigroups_pybind11/presentation/__init__.py
@@ -216,7 +216,7 @@ class InversePresentation(Presentation):
         :param p: the :any:`Presentation` to construct from.
         :type p: Presentation
         """
-        super().__init__(*args, *kwargs)
+        super().__init__(*args, **kwargs)
         if _to_cxx(self) is not None:
             return
         assert isinstance(args[0], Presentation)

--- a/tests/test_present.py
+++ b/tests/test_present.py
@@ -1440,6 +1440,15 @@ def test_inverse_presentation_constructors_037():
     check_constructors(ip)
 
 
+@pytest.mark.parametrize("word, empty", [(str, ""), (list[int], [])])
+def test_inverse_presentation_keyword_constructor(word, empty):
+    p = InversePresentation(word=word)
+    assert p.alphabet() == empty
+    assert p.inverses() == empty
+    assert p.rules == []
+    assert p.py_template_params == (word,)
+
+
 def test_inverse_constructors_038():
     check_inverse_constructors(to_string)
     check_inverse_constructors(to_word)


### PR DESCRIPTION
`InversePresentation(word=str)` currently forwards the keyword name as a positional alphabet, producing `"word"`; `word=list[int]` also incorrectly creates a string presentation. Forward `**kwargs` so the parent constructor receives the requested word type and creates an empty presentation.

Add a parameterized regression test for both supported word types, checking the empty alphabet, inverses, rules, and selected word type.

Validation: all 98 tests in `tests/test_present.py` and `tests/test_presentation_examples.py` pass using the source Python package with the existing Python 3.13 native build. Both regression cases fail with the original typo restored in a temporary copy. Ruff lint and format checks pass for both changed files.

Fixes #483.
