### PR TITLE
Validate Presentation constructor keyword arguments

### DIFF
--- a/src/libsemigroups_pybind11/presentation/__init__.py
+++ b/src/libsemigroups_pybind11/presentation/__init__.py
@@ -125,7 +125,7 @@ class Presentation(_CxxWrapper):
         """
         # super().__init__ checks if there are unexpected kwargs,
         # and sets _cxx_obj if the unique argument is a cxx_obj of type in _all_wrapped_cxx_types
-        super().__init__(*args, optional_kwargs="word")
+        super().__init__(*args, optional_kwargs=("word",), **kwargs)
         if _to_cxx(self) is not None:
             return
 

--- a/src/libsemigroups_pybind11/presentation/__init__.py
+++ b/src/libsemigroups_pybind11/presentation/__init__.py
@@ -216,7 +216,7 @@ class InversePresentation(Presentation):
         :param p: the :any:`Presentation` to construct from.
         :type p: Presentation
         """
-        super().__init__(*args, *kwargs)
+        super().__init__(*args, **kwargs)
         if _to_cxx(self) is not None:
             return
         assert isinstance(args[0], Presentation)

--- a/tests/test_present.py
+++ b/tests/test_present.py
@@ -872,6 +872,29 @@ def test_constructors_000():
     check_constructors(p)
 
 
+@pytest.mark.parametrize("presentation_type", [Presentation, InversePresentation])
+@pytest.mark.parametrize("word", [str, list[int]])
+@pytest.mark.parametrize("keyword", ["typo", "w", "or"])
+def test_presentation_constructor_rejects_unexpected_keyword(presentation_type, word, keyword):
+    with pytest.raises(TypeError):
+        presentation_type(word=word, **{keyword: True})
+
+
+@pytest.mark.parametrize("presentation_type", [Presentation, InversePresentation])
+@pytest.mark.parametrize("keyword", ["typo", "w", "or"])
+def test_presentation_constructor_rejects_unknown_keyword_name(presentation_type, keyword):
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        presentation_type(**{keyword: str})
+
+
+@pytest.mark.parametrize("presentation_type", [Presentation, InversePresentation])
+@pytest.mark.parametrize("word, empty", [(str, ""), (list[int], [])])
+def test_presentation_constructor_accepts_word_keyword(presentation_type, word, empty):
+    p = presentation_type(word=word)
+    assert p.alphabet() == empty
+    assert p.py_template_params == (word,)
+
+
 def test_strings_001():
     p = Presentation("abc")
     assert p.alphabet() == "abc"

--- a/tests/test_present.py
+++ b/tests/test_present.py
@@ -1440,6 +1440,15 @@ def test_inverse_presentation_constructors_037():
     check_constructors(ip)
 
 
+@pytest.mark.parametrize("word, empty", [(str, ""), (list[int], [])])
+def test_inverse_presentation_keyword_constructor(word, empty):
+    p = InversePresentation(word=word)
+    assert p.alphabet() == empty
+    assert p.inverses() == empty
+    assert p.rules == []
+    assert p.py_template_params == (word,)
+
+
 def test_inverse_constructors_038():
     check_inverse_constructors(to_string)
     check_inverse_constructors(to_word)


### PR DESCRIPTION
`Presentation(word=str, typo=True)` silently ignores the unexpected keyword because its constructor never forwards keyword arguments to the base validator. The same behavior affects `InversePresentation` after #488.

Forward `**kwargs` to the base constructor and declare the allowed keyword as `("word",)`. Using a tuple makes validation check complete keyword names rather than accepting substrings such as `"w"` or `"or"`.

Add parameterized tests covering both presentation classes, both supported word types, unexpected keywords alongside `word`, unknown keyword names on their own, and valid keyword construction.

Validation: all 120 tests in `tests/test_present.py` and `tests/test_presentation_examples.py` pass using the source Python package with the existing Python 3.13 native build. Before the fix, 18 new regression cases failed and the four valid-construction cases passed. Ruff lint and format checks pass for both changed files.

This PR is based on #488 so its diff contains only the keyword validation fix and tests. It should be retargeted to `main` after #488 merges.

AI disclosure: OpenAI Codex authored the code changes, regression tests, and this PR description at the maintainer's request.
