### PR TITLE
Avoid temporary objects in copy bindings

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -23,6 +23,7 @@
 // TODO Left/RightActionPerm
 
 // C++ stl headers....
+#include <memory>       // for make_unique
 #include <string_view>  // for string_view
 
 // libsemigroups headers
@@ -115,10 +116,12 @@ In this documentation we refer to:
       // Action code.
       thing.def(py::init<>());
 
-      thing.def("__copy__", [](Action_ const& self) { return Action_(self); });
+      thing.def("__copy__", [](Action_ const& self) {
+        return std::make_unique<Action_>(self);
+      });
       thing.def(
           "copy",
-          [](Action_ const& self) { return Action_(self); },
+          [](Action_ const& self) { return std::make_unique<Action_>(self); },
           R"pbdoc(
 :sig=(self: Action) -> Action:
 

--- a/src/aho-corasick.cpp
+++ b/src/aho-corasick.cpp
@@ -17,6 +17,7 @@
 //
 
 // C++ stl headers....
+#include <memory>  // for make_unique
 #include <string>  // for string
 
 // libsemigroups....
@@ -73,7 +74,9 @@ the empty word :math:`\varepsilon`.)pbdoc");
 
     thing.def(
         "copy",
-        [](AhoCorasick const& self) { return AhoCorasick(self); },
+        [](AhoCorasick const& self) {
+          return std::make_unique<AhoCorasick>(self);
+        },
         R"pbdoc(
 :sig=(self: AhoCorasick) -> AhoCorasick:
 
@@ -81,8 +84,9 @@ Copy a :any:`AhoCorasick` object.
 
 :returns: A copy.
 :rtype: AhoCorasick)pbdoc");
-    thing.def("__copy__",
-              [](AhoCorasick const& self) { return AhoCorasick(self); });
+    thing.def("__copy__", [](AhoCorasick const& self) {
+      return std::make_unique<AhoCorasick>(self);
+    });
 
     thing.def(
         "child",

--- a/src/alphabet.cpp
+++ b/src/alphabet.cpp
@@ -16,6 +16,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
+
 // libsemigroups headers
 #include <libsemigroups/alphabet.hpp>
 
@@ -73,8 +76,9 @@ letters is significant: it is the order used by :any:`letter` and
 
       thing.def("__len__", &Alphabet_::size);
 
-      thing.def("__copy__",
-                [](Alphabet_ const& self) { return Alphabet(self); });
+      thing.def("__copy__", [](Alphabet_ const& self) {
+        return std::make_unique<Alphabet_>(self);
+      });
 
       thing.def(
           "__iter__",
@@ -250,7 +254,9 @@ This function replaces the alphabet by the first *n* human-readable letters.
 
       thing.def(
           "copy",
-          [](Alphabet_ const& self) { return Alphabet(self); },
+          [](Alphabet_ const& self) {
+            return std::make_unique<Alphabet_>(self);
+          },
           R"pbdoc(
 :sig=(self: Alphabet) -> Alphabet:
 

--- a/src/bipart.cpp
+++ b/src/bipart.cpp
@@ -16,6 +16,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
+
 // libsemigroups headers
 #include <libsemigroups/bipart.hpp>
 
@@ -52,12 +55,14 @@ See also :any:`Bipartition` for more details and context.
     thing.def(py::self < py::self);
     thing.def(py::self == py::self);
 
-    thing.def("__copy__", [](Blocks const& self) { return Blocks(self); });
+    thing.def("__copy__", [](Blocks const& self) {
+      return std::make_unique<Blocks>(self);
+    });
     thing.def("__hash__", &Blocks::hash_value, py::is_operator());
 
     thing.def(
         "copy",
-        [](Blocks const& self) { return Blocks(self); },
+        [](Blocks const& self) { return std::make_unique<Blocks>(self); },
         R"pbdoc(
 Copy a Blocks object.
 
@@ -258,8 +263,9 @@ for more details.
     thing.def("__repr__", [](Bipartition const& self) {
       return to_human_readable_repr(self, "[]");
     });
-    thing.def("__copy__",
-              [](Bipartition const& self) { return Bipartition(self); });
+    thing.def("__copy__", [](Bipartition const& self) {
+      return std::make_unique<Bipartition>(self);
+    });
     thing.def("__hash__", &Bipartition::hash_value, py::is_operator());
     thing.def(
         "__getitem__",
@@ -271,7 +277,9 @@ for more details.
 
     thing.def(
         "copy",
-        [](Bipartition const& self) { return Bipartition(self); },
+        [](Bipartition const& self) {
+          return std::make_unique<Bipartition>(self);
+        },
         R"pbdoc(
 Copy a Bipartition object.
 

--- a/src/bmat8.cpp
+++ b/src/bmat8.cpp
@@ -20,6 +20,9 @@
 // TODO
 // * iwyu
 
+// C++ stl headers....
+#include <memory>  // for make_unique
+
 // libsemigroups headers
 #include <libsemigroups/bmat8.hpp>
 
@@ -208,14 +211,15 @@ This function always returns ``8``.
 
     thing.def(
         "copy",
-        [](BMat8 const& self) { return BMat8(self); },
+        [](BMat8 const& self) { return std::make_unique<BMat8>(self); },
         R"pbdoc(
 Copy a BMat8.
 
 :returns: A copy of the argument.
 :rtype: BMat8
 )pbdoc");
-    thing.def("__copy__", [](BMat8 const& self) { return BMat8(self); });
+    thing.def("__copy__",
+              [](BMat8 const& self) { return std::make_unique<BMat8>(self); });
 
     thing.def("to_int",
               &BMat8::to_int,

--- a/src/cong-common.cpp
+++ b/src/cong-common.cpp
@@ -18,6 +18,8 @@
 
 #include "cong-common.hpp"  // for doc
 
+// C++ stl headers....
+#include <memory>  // for make_unique
 #include <string_view>
 
 // libsemigroups headers
@@ -482,7 +484,7 @@ had been newly constructed from *knd* and *p*.
                 doc                           extra_doc) {
     thing.def(
         "copy",
-        [](Thing const& self) { return Thing(self); },
+        [](Thing const& self) { return std::make_unique<Thing>(self); },
         make_doc(R"pbdoc(
 :sig=(self: {name}) -> {name}:
 {only_document_once}
@@ -496,7 +498,8 @@ Copy a :any:`{name}` object.
                  name,
                  extra_doc));
 
-    thing.def("__copy__", [](Thing const& self) { return Thing(self); });
+    thing.def("__copy__",
+              [](Thing const& self) { return std::make_unique<Thing>(self); });
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -18,6 +18,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
+
 // libsemigroups headers
 #include <libsemigroups/dot.hpp>
 
@@ -226,10 +229,10 @@ A list of default HTML/hex colours.
 Default constructor that constructs an empty :any:`Dot` object with no nodes,
 edges, attributes, or subgraphs.
 )pbdoc");
-    dot.def("__copy__", [](Dot const& d) { return Dot(d); });
+    dot.def("__copy__", [](Dot const& d) { return std::make_unique<Dot>(d); });
     dot.def(
         "copy",
-        [](Dot const& d) { return Dot(d); },
+        [](Dot const& d) { return std::make_unique<Dot>(d); },
         R"pbdoc(
 :sig=(self: Dot) -> Dot:
 

--- a/src/forest.cpp
+++ b/src/forest.cpp
@@ -21,6 +21,7 @@
 
 // C++ stl headers....
 #include <initializer_list>  // for initializer_list
+#include <memory>            // for make_unique
 
 // libsemigroups....
 #include <libsemigroups/forest.hpp>  // for Forest
@@ -49,10 +50,11 @@ connected components of a word graph.
 
       thing.def("__repr__",
                 [](Forest const& f) { return to_human_readable_repr(f); });
-      thing.def("__copy__", [](Forest const& f) { return Forest(f); });
+      thing.def("__copy__",
+                [](Forest const& f) { return std::make_unique<Forest>(f); });
       thing.def(
           "copy",
-          [](Forest const& f) { return Forest(f); },
+          [](Forest const& f) { return std::make_unique<Forest>(f); },
           R"pbdoc(
 Copy a :any:`Forest` object.
 
@@ -617,7 +619,7 @@ breadth-first traversal).)pbdoc");
       });
 
       thing.def("__copy__", [](forest::PathsToRoots const& pfr) {
-        return forest::PathsToRoots(pfr);
+        return std::make_unique<forest::PathsToRoots>(pfr);
       });
 
       thing.def(py::init<Forest const&>(),
@@ -662,7 +664,7 @@ would have been in if it had been newly constructed from *f*.
       thing.def(
           "copy",
           [](forest::PathsToRoots const& pfr) {
-            return forest::PathsToRoots(pfr);
+            return std::make_unique<forest::PathsToRoots>(pfr);
           },
           R"pbdoc(
 :sig=(self: PathsToRoots) -> PathsToRoots:
@@ -759,7 +761,7 @@ breadth-first traversal).)pbdoc");
       });
 
       thing.def("__copy__", [](forest::PathsFromRoots const& pfr) {
-        return forest::PathsFromRoots(pfr);
+        return std::make_unique<forest::PathsFromRoots>(pfr);
       });
 
       thing.def(py::init<Forest const&>(),
@@ -804,7 +806,7 @@ would have been in if it had been newly constructed from *f*.
       thing.def(
           "copy",
           [](forest::PathsFromRoots const& pfr) {
-            return forest::PathsFromRoots(pfr);
+            return std::make_unique<forest::PathsFromRoots>(pfr);
           },
           R"pbdoc(
 :sig=(self: PathsFromRoots) -> PathsFromRoots:

--- a/src/froidure-pin.cpp
+++ b/src/froidure-pin.cpp
@@ -16,6 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
 #include <string>
 
 // libsemigroups headers
@@ -52,8 +54,9 @@ namespace libsemigroups {
         return to_human_readable_repr(x);
       });
 
-      thing.def("__copy__",
-                [](FroidurePin_ const& self) { return FroidurePin_(self); });
+      thing.def("__copy__", [](FroidurePin_ const& self) {
+        return std::make_unique<FroidurePin_>(self);
+      });
 
       thing.def(
           "init",
@@ -72,7 +75,9 @@ the same state as if it had just been default constructed.
 
       thing.def(
           "copy",
-          [](FroidurePin_ const& self) { return FroidurePin_(self); },
+          [](FroidurePin_ const& self) {
+            return std::make_unique<FroidurePin_>(self);
+          },
           R"pbdoc(
 :sig=(self: FroidurePin) -> FroidurePin:
 

--- a/src/gabow.cpp
+++ b/src/gabow.cpp
@@ -23,6 +23,7 @@
 #include <cstddef>           // for uint32_t
 #include <cstdint>           // for uint64_t
 #include <initializer_list>  // for initializer_list
+#include <memory>            // for make_unique
 #include <string>            // for to_string, basic_string
 #include <vector>            // for vector
 
@@ -69,11 +70,12 @@ at most :math:`O(mn)` where ``m`` is :any:`WordGraph.number_of_nodes()` and
     thing.def("__repr__",
               [](Gabow_ const& g) { return to_human_readable_repr(g); });
 
-    thing.def("__copy__", [](Gabow_ const& g) { return Gabow_(g); });
+    thing.def("__copy__",
+              [](Gabow_ const& g) { return std::make_unique<Gabow_>(g); });
 
     thing.def(
         "copy",
-        [](Gabow_ const& self) { return Gabow_(self); },
+        [](Gabow_ const& self) { return std::make_unique<Gabow_>(self); },
         R"pbdoc(
 :sig=(self: Gabow) -> Gabow:
 

--- a/src/hpcombi.cpp
+++ b/src/hpcombi.cpp
@@ -16,6 +16,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
+
 // libsemigroups headers
 #include <libsemigroups/hpcombi.hpp>
 
@@ -93,7 +96,8 @@ The functionality described on this page is only available if
 
       thing.def("__len__", [](Vect16 const&) { return Vect16::size(); });
 
-      thing.def("__copy__", [](Vect16 const& v) { return Vect16(v); });
+      thing.def("__copy__",
+                [](Vect16 const& v) { return std::make_unique<Vect16>(v); });
 
       thing.def("__hash__",
                 [](Vect16 const& v) { return std::hash<Vect16>{}(v); });
@@ -179,7 +183,7 @@ is padded with ``0`` values at the end.
 
       thing.def(
           "copy",
-          [](Vect16 const& v) { return Vect16(v); },
+          [](Vect16 const& v) { return std::make_unique<Vect16>(v); },
           R"pbdoc(
 :sig=(self: Vect16) -> Vect16:
 
@@ -576,7 +580,9 @@ The functionality described on this page is only available if
           [](PTransf16 const& x, PTransf16 const& y) { return y * x; },
           py::is_operator());
 
-      thing.def("__copy__", [](PTransf16 const& v) { return PTransf16(v); });
+      thing.def("__copy__", [](PTransf16 const& v) {
+        return std::make_unique<PTransf16>(v);
+      });
 
       ////////////////////////////////////////////////////////////////////////
       // Constructors
@@ -677,7 +683,7 @@ This function returns the identity :any:`PTransf16` which fixes every value in
 
       thing.def(
           "copy",
-          [](PTransf16 const& v) { return PTransf16(v); },
+          [](PTransf16 const& v) { return std::make_unique<PTransf16>(v); },
           R"pbdoc(
 :sig=(self: PTransf16) -> PTransf16:
 
@@ -1226,7 +1232,9 @@ The functionality described on this page is only available if
       thing.def("__int__",
                 [](Transf16 const& x) { return static_cast<uint64_t>(x); });
 
-      thing.def("__copy__", [](Transf16 const& v) { return Transf16(v); });
+      thing.def("__copy__", [](Transf16 const& v) {
+        return std::make_unique<Transf16>(v);
+      });
 
       thing.def(
           "__mul__",
@@ -1309,7 +1317,7 @@ This function constructs a :any:`Transf16` from its integer representation *n*.
 
       thing.def(
           "copy",
-          [](Transf16 const& v) { return Transf16(v); },
+          [](Transf16 const& v) { return std::make_unique<Transf16>(v); },
           R"pbdoc(
 :sig=(self: Transf16) -> Transf16:
 
@@ -1409,7 +1417,9 @@ The functionality described on this page is only available if
       // Special methods
       ////////////////////////////////////////////////////////////////////////
 
-      thing.def("__copy__", [](Perm16 const& self) { return Perm16(self); });
+      thing.def("__copy__", [](Perm16 const& self) {
+        return std::make_unique<Perm16>(self);
+      });
 
       thing.def("__int__",
                 [](Perm16 const& x) { return static_cast<uint64_t>(x); });
@@ -1610,7 +1620,7 @@ This function constructs a :any:`Perm16` from its integer representation *n*.
 
       thing.def(
           "copy",
-          [](Perm16 const& v) { return Perm16(v); },
+          [](Perm16 const& v) { return std::make_unique<Perm16>(v); },
           R"pbdoc(
 :sig=(self: Perm16) -> Perm16:
 
@@ -2164,7 +2174,9 @@ The functionality described on this page is only available if
       // Special methods
       ////////////////////////////////////////////////////////////////////////
 
-      thing.def("__copy__", [](PPerm16 const& self) { return PPerm16(self); });
+      thing.def("__copy__", [](PPerm16 const& self) {
+        return std::make_unique<PPerm16>(self);
+      });
 
       thing.def("__repr__",
                 [](PPerm16 const& self) { return repr(self, "PPerm16"); });
@@ -2294,7 +2306,7 @@ is padded with fixed points at the end.
 
       thing.def(
           "copy",
-          [](PPerm16 const& v) { return PPerm16(v); },
+          [](PPerm16 const& v) { return std::make_unique<PPerm16>(v); },
           R"pbdoc(
 :sig=(self: PPerm16) -> PPerm16:
 

--- a/src/knuth-bendix.cpp
+++ b/src/knuth-bendix.cpp
@@ -16,6 +16,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
+
 // libsemigroups headers
 #include <libsemigroups/knuth-bendix-helpers.hpp>
 #include <libsemigroups/knuth-bendix.hpp>
@@ -340,11 +343,13 @@ Check if all rules are reduced with respect to each other.
       });
 
       thing.def("__copy__", [](NormalFormRange const& self) {
-        return NormalFormRange(self);
+        return std::make_unique<NormalFormRange>(self);
       });
       thing.def(
           "copy",
-          [](NormalFormRange const& self) { return NormalFormRange(self); },
+          [](NormalFormRange const& self) {
+            return std::make_unique<NormalFormRange>(self);
+          },
           R"pbdoc(
 :sig=(self: NormalFormRange) -> NormalFormRange:
 

--- a/src/konieczny.cpp
+++ b/src/konieczny.cpp
@@ -17,6 +17,9 @@
 // along with this program.  If not, see <http://www. gnu. org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
+
 // libsemigroups headers
 #include <libsemigroups/bmat-adapters.hpp>
 #include <libsemigroups/bmat8.hpp>
@@ -73,11 +76,14 @@ Currently :any:`Konieczny` supports the following element types:
       thing.def("__repr__", [](Konieczny_ const& self) {
         return to_human_readable_repr(self);
       });
-      thing.def("__copy__",
-                [](Konieczny_ const& self) { return Konieczny_(self); });
+      thing.def("__copy__", [](Konieczny_ const& self) {
+        return std::make_unique<Konieczny_>(self);
+      });
       thing.def(
           "copy",
-          [](Konieczny_ const& self) { return Konieczny_(self); },
+          [](Konieczny_ const& self) {
+            return std::make_unique<Konieczny_>(self);
+          },
           R"pbdoc(
 :sig=(self: Konieczny) -> Konieczny:
 Copy a Konieczny.

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -303,7 +303,8 @@ submodule :any:`libsemigroups_pybind11.matrix`.
 
       thing.def("__repr__", repr);
       thing.def("__hash__", &Mat::hash_value);
-      thing.def("__copy__", [](Mat const& x) { return Mat(x); });
+      thing.def("__copy__",
+                [](Mat const& x) { return std::make_unique<Mat>(x); });
       thing.def(
           "__getitem__",
           [](Mat const& mat, py::tuple xy) {
@@ -494,7 +495,9 @@ submodule :any:`libsemigroups_pybind11.matrix`.
       thing.def("__pow__", &matrix::pow<Mat>);
 
       thing.def(
-          "copy", [](Mat const& x) { return Mat(x); }, R"pbdoc(
+          "copy",
+          [](Mat const& x) { return std::make_unique<Mat>(x); },
+          R"pbdoc(
 :sig=(self: Matrix) -> Matrix:
 Copy a :any:`Matrix` object.
 

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -17,6 +17,7 @@
 //
 
 // C++ stl headers....
+#include <memory>  // for make_unique
 #include <string>  // for string
 #include <vector>  // for vector
 
@@ -1274,9 +1275,11 @@ Constructs an object whose call operator compares either ``str`` or
       thing.def("__repr__",
                 [](Cmp const& self) { return to_human_readable_repr(self); });
 
-      thing.def("__copy__", [](Cmp const& self) { return Cmp(self); });
+      thing.def("__copy__",
+                [](Cmp const& self) { return std::make_unique<Cmp>(self); });
 
-      thing.def("copy", [](Cmp const& self) { return Cmp(self); });
+      thing.def("copy",
+                [](Cmp const& self) { return std::make_unique<Cmp>(self); });
 
       thing.def(
           "__call__",
@@ -1338,8 +1341,10 @@ Construct a comparison object for ``str`` or ``list[int]`` words.
                     .c_str());
       thing.def("__repr__",
                 [](Cmp const& self) { return to_human_readable_repr(self); });
-      thing.def("__copy__", [](Cmp const& self) { return Cmp(self); });
-      thing.def("copy", [](Cmp const& self) { return Cmp(self); });
+      thing.def("__copy__",
+                [](Cmp const& self) { return std::make_unique<Cmp>(self); });
+      thing.def("copy",
+                [](Cmp const& self) { return std::make_unique<Cmp>(self); });
       thing.def(
           "init",
           [](Cmp& self, std::vector<size_t> const& values) -> Cmp& {
@@ -1472,10 +1477,11 @@ The two arguments must have the same size.
                     .c_str());
       thing.def("__repr__",
                 [](Cmp const& self) { return to_human_readable_repr(self); });
-      thing.def("__copy__", [](Cmp const& self) { return Cmp(self); });
+      thing.def("__copy__",
+                [](Cmp const& self) { return std::make_unique<Cmp>(self); });
       thing.def(
           "copy",
-          [](Cmp const& self) { return Cmp(self); },
+          [](Cmp const& self) { return std::make_unique<Cmp>(self); },
           fmt::format(R"pbdoc(
 :sig=(self: {0}) -> {0}:
 Copy a comparison object.
@@ -1696,11 +1702,13 @@ for the call operator.
         return to_human_readable_repr(self);
       });
 
-      thing.def("__copy__", [](LexCmp_ const& self) { return LexCmp_(self); });
+      thing.def("__copy__", [](LexCmp_ const& self) {
+        return std::make_unique<LexCmp_>(self);
+      });
 
       thing.def(
           "copy",
-          [](LexCmp_ const& self) { return LexCmp_(self); },
+          [](LexCmp_ const& self) { return std::make_unique<LexCmp_>(self); },
           R"pbdoc(
 :sig=(self: LexCmp) -> LexCmp:
 Copy a comparison object.
@@ -1892,12 +1900,15 @@ type for the call operator.
         return to_human_readable_repr(self);
       });
 
-      thing.def("__copy__",
-                [](LenLexCmp_ const& self) { return LenLexCmp_(self); });
+      thing.def("__copy__", [](LenLexCmp_ const& self) {
+        return std::make_unique<LenLexCmp_>(self);
+      });
 
       thing.def(
           "copy",
-          [](LenLexCmp_ const& self) { return LenLexCmp_(self); },
+          [](LenLexCmp_ const& self) {
+            return std::make_unique<LenLexCmp_>(self);
+          },
           R"pbdoc(
 :sig=(self: LenLexCmp) -> LenLexCmp:
 Copy a comparison object.
@@ -2089,11 +2100,13 @@ letters in *alphabet* also fixes the accepted word type for the call operator.
         return to_human_readable_repr(self);
       });
 
-      thing.def("__copy__", [](RPOCmp_ const& self) { return RPOCmp_(self); });
+      thing.def("__copy__", [](RPOCmp_ const& self) {
+        return std::make_unique<RPOCmp_>(self);
+      });
 
       thing.def(
           "copy",
-          [](RPOCmp_ const& self) { return RPOCmp_(self); },
+          [](RPOCmp_ const& self) { return std::make_unique<RPOCmp_>(self); },
           R"pbdoc(
 :sig=(self: RPOCmp) -> RPOCmp:
 Copy a comparison object.
@@ -2286,12 +2299,15 @@ call operator.
         return to_human_readable_repr(self);
       });
 
-      thing.def("__copy__",
-                [](RevRPOCmp_ const& self) { return RevRPOCmp_(self); });
+      thing.def("__copy__", [](RevRPOCmp_ const& self) {
+        return std::make_unique<RevRPOCmp_>(self);
+      });
 
       thing.def(
           "copy",
-          [](RevRPOCmp_ const& self) { return RevRPOCmp_(self); },
+          [](RevRPOCmp_ const& self) {
+            return std::make_unique<RevRPOCmp_>(self);
+          },
           R"pbdoc(
 :sig=(self: RevRPOCmp) -> RevRPOCmp:
 Copy a comparison object.
@@ -2486,12 +2502,15 @@ for the call operator.
         return to_human_readable_repr(self);
       });
 
-      thing.def("__copy__",
-                [](RevLexCmp_ const& self) { return RevLexCmp_(self); });
+      thing.def("__copy__", [](RevLexCmp_ const& self) {
+        return std::make_unique<RevLexCmp_>(self);
+      });
 
       thing.def(
           "copy",
-          [](RevLexCmp_ const& self) { return RevLexCmp_(self); },
+          [](RevLexCmp_ const& self) {
+            return std::make_unique<RevLexCmp_>(self);
+          },
           R"pbdoc(
 :sig=(self: RevLexCmp) -> RevLexCmp:
 Copy a comparison object.
@@ -2687,12 +2706,15 @@ accepted word type for the call operator.
         return to_human_readable_repr(self);
       });
 
-      thing.def("__copy__",
-                [](RevLenLexCmp_ const& self) { return RevLenLexCmp_(self); });
+      thing.def("__copy__", [](RevLenLexCmp_ const& self) {
+        return std::make_unique<RevLenLexCmp_>(self);
+      });
 
       thing.def(
           "copy",
-          [](RevLenLexCmp_ const& self) { return RevLenLexCmp_(self); },
+          [](RevLenLexCmp_ const& self) {
+            return std::make_unique<RevLenLexCmp_>(self);
+          },
           R"pbdoc(
 :sig=(self: RevLenLexCmp) -> RevLenLexCmp:
 Copy a comparison object.

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -19,6 +19,7 @@
 // C++ stl headers....
 #include <cstddef>  // for uint32_t
 #include <cstdint>  // for uint64_t
+#include <memory>   // for make_unique
 
 // libsemigroups....
 #include <libsemigroups/constants.hpp>   // for operator!=, operator==
@@ -63,10 +64,11 @@ paths in a :any:`WordGraph` from a given :any:`source` (to a possible
 )pbdoc");
     thing1.def("__repr__",
                [](Paths_ const& p) { return to_human_readable_repr(p); });
-    thing1.def("__copy__", [](Paths_ const& p) { return Paths_(p); });
+    thing1.def("__copy__",
+               [](Paths_ const& p) { return std::make_unique<Paths_>(p); });
     thing1.def(
         "copy",
-        [](Paths_ const& self) { return Paths_(self); },
+        [](Paths_ const& self) { return std::make_unique<Paths_>(self); },
         R"pbdoc(
 :sig=(self: Paths) -> Paths:
 

--- a/src/pbr.cpp
+++ b/src/pbr.cpp
@@ -16,6 +16,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
+
 // libsemigroups headers
 #include <libsemigroups/exception.hpp>
 #include <libsemigroups/pbr.hpp>
@@ -165,7 +168,8 @@ Returns a newly constructed PBR equal to the product of *self* and
     thing.def("__gt__", [](PBR const& a, PBR const& b) { return a > b; });
     thing.def("__le__", [](PBR const& a, PBR const& b) { return a <= b; });
     thing.def("__ne__", [](PBR const& a, PBR const& b) { return a != b; });
-    thing.def("__copy__", [](PBR const& self) { return PBR(self); });
+    thing.def("__copy__",
+              [](PBR const& self) { return std::make_unique<PBR>(self); });
     thing.def("__hash__", &PBR::hash_value, py::is_operator());
     thing.def(
         "__getitem__",
@@ -235,7 +239,7 @@ then bad things will happen.
 )pbdoc");
     thing.def(
         "copy",
-        [](PBR const& self) { return PBR(self); },
+        [](PBR const& self) { return std::make_unique<PBR>(self); },
         R"pbdoc(
 Copy a :any:`PBR` object.
 

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -20,6 +20,7 @@
 #include <cstddef>  // for size_t
 
 // C++ stl headers....
+#include <memory>  // for make_unique
 #include <string>  // for string, basic_string, oper...
 
 // libsemigroups....
@@ -85,7 +86,9 @@ Default constructor.
 Constructs an empty presentation with no rules and no alphabet.)pbdoc");
       thing.def(
           "copy",
-          [](Presentation_ const& self) { return Presentation_(self); },
+          [](Presentation_ const& self) {
+            return std::make_unique<Presentation_>(self);
+          },
           R"pbdoc(
 :sig=(self: Presentation) -> Presentation:
 
@@ -94,8 +97,9 @@ Copy a :any:`Presentation` object.
 :returns: A copy.
 :rtype: Presentation
 )pbdoc");
-      thing.def("__copy__",
-                [](Presentation_ const& that) { return Presentation_(that); });
+      thing.def("__copy__", [](Presentation_ const& that) {
+        return std::make_unique<Presentation_>(that);
+      });
       thing.def(
           "alphabet",
           [](Presentation_ const& self) { return self.alphabet(); },
@@ -2045,7 +2049,7 @@ no inverses.)pbdoc");
       thing.def(
           "copy",
           [](InversePresentation_ const& self) {
-            return InversePresentation_(self);
+            return std::make_unique<InversePresentation_>(self);
           },
           R"pbdoc(
 :sig=(self: InversePresentation) -> InversePresentation:
@@ -2056,7 +2060,7 @@ Copy a :any:`InversePresentation` object.
 :rtype: InversePresentation
 )pbdoc");
       thing.def("__copy__", [](InversePresentation_ const& that) {
-        return InversePresentation_(that);
+        return std::make_unique<InversePresentation_>(that);
       });
 
       thing.def("inverse",

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -16,6 +16,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
+
 // C++ headers
 #include <type_traits>  // for std::is_same_v
 
@@ -160,7 +163,7 @@ Default construct a :any:`Reporter` object such that the following hold:
 )pbdoc");
     thing.def(
         "copy",
-        [](Reporter const& self) { return Reporter(self); },
+        [](Reporter const& self) { return std::make_unique<Reporter>(self); },
         R"pbdoc(
 :sig=(self: Reporter) -> Reporter:
 
@@ -169,7 +172,9 @@ Copy a :any:`Reporter` object.
 :returns: A copy.
 :rtype: Reporter
 )pbdoc");
-    thing.def("__copy__", [](Reporter const& self) { return Reporter(self); });
+    thing.def("__copy__", [](Reporter const& self) {
+      return std::make_unique<Reporter>(self);
+    });
     thing.def(
         "init",
         [](Reporter& r) -> Reporter& { return r.init(); },

--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -17,6 +17,7 @@
 //
 
 // C++ stl headers....
+#include <memory>  // for make_unique
 #include <pybind11/detail/common.h>
 #include <vector>  // for vector
 
@@ -657,11 +658,12 @@ search conducted by an object of this type.
                           doc_type)
                   .c_str());
 
-    thing.def("__copy__", [](Thing const& self) { return Thing(self); });
+    thing.def("__copy__",
+              [](Thing const& self) { return std::make_unique<Thing>(self); });
 
     thing.def(
         "copy",
-        [](Thing const& self) { return Thing(self); },
+        [](Thing const& self) { return std::make_unique<Thing>(self); },
         fmt::format(R"pbdoc(
 Copy a :any:`{0}` object.
 
@@ -1020,10 +1022,12 @@ Default constructor.
 Constructs a :any:`SimsStats` object with all statistics set to zero.
 )pbdoc");
 
-    st.def("__copy__", [](SimsStats const& self) { return SimsStats(self); });
+    st.def("__copy__", [](SimsStats const& self) {
+      return std::make_unique<SimsStats>(self);
+    });
     st.def(
         "copy",
-        [](SimsStats const& self) { return SimsStats(self); },
+        [](SimsStats const& self) { return std::make_unique<SimsStats>(self); },
         R"pbdoc(
 Copy a :any:`SimsStats` object.
 

--- a/src/stephen.cpp
+++ b/src/stephen.cpp
@@ -17,6 +17,7 @@
 //
 
 // C++ stl headers....
+#include <memory>    // for make_unique
 #include <optional>  // for optional, nullopt
 
 // libsemigroups headers
@@ -77,8 +78,9 @@ originates in :cite:`Stephen1987aa`.
       thing.def("__repr__", [](Stephen_ const& stephen) {
         return to_human_readable_repr(stephen);
       });
-      thing.def("__copy__",
-                [](Stephen_ const& self) { return Stephen_(self); });
+      thing.def("__copy__", [](Stephen_ const& self) {
+        return std::make_unique<Stephen_>(self);
+      });
       // Not directly usable so not included
       //       thing.def(py::init<>(), R"pbdoc(
       // This function default constructs an empty instance of :any:`Stephen`.
@@ -96,7 +98,7 @@ This function constructs :any:`Stephen` from a presentation.
 )pbdoc");
       thing.def(
           "copy",
-          [](Stephen_ const& self) { return Stephen_(self); },
+          [](Stephen_ const& self) { return std::make_unique<Stephen_>(self); },
           R"pbdoc(
 :sig=(self: Stephen) -> Stephen:
 

--- a/src/transf.cpp
+++ b/src/transf.cpp
@@ -16,6 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
 #include <stdexcept>
 
 // libsemigroups headers
@@ -101,7 +103,7 @@ the image of the point ``i`` under the {0} is ``imgs[i]``.
       ////////////////////////////////////////////////////////////////////////
 
       thing.def("__copy__", [](PTransfSubclass const& self) {
-        return PTransfSubclass(self);
+        return std::make_unique<PTransfSubclass>(self);
       });
 
       thing.def(
@@ -137,7 +139,9 @@ the image of the point ``i`` under the {0} is ``imgs[i]``.
 
       thing.def(
           "copy",
-          [](PTransfSubclass const& self) { return PTransfSubclass(self); },
+          [](PTransfSubclass const& self) {
+            return std::make_unique<PTransfSubclass>(self);
+          },
           fmt::format(
               R"pbdoc(
 :sig=(self: {1}) -> {1}:

--- a/src/ukkonen.cpp
+++ b/src/ukkonen.cpp
@@ -17,6 +17,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+// C++ stl headers....
+#include <memory>  // for make_unique
+
 // libsemigroups headers
 #include <libsemigroups/types.hpp>  // for word_type
 #include <libsemigroups/ukkonen.hpp>
@@ -622,7 +625,9 @@ Construct from index and position.
 )pbdoc");
     state.def(
         "copy",
-        [](Ukkonen::State const& self) { return Ukkonen::State(self); },
+        [](Ukkonen::State const& self) {
+          return std::make_unique<Ukkonen::State>(self);
+        },
         R"pbdoc(
 :sig=(self: Ukkonen.State) -> Ukkonen.State:
 
@@ -631,8 +636,9 @@ Copy a :any:`Ukkonen.State` object.
 :returns: A copy.
 :rtype: Ukkonen.State
 )pbdoc");
-    state.def("__copy__",
-              [](Ukkonen::State const& that) { return Ukkonen::State(that); });
+    state.def("__copy__", [](Ukkonen::State const& that) {
+      return std::make_unique<Ukkonen::State>(that);
+    });
     state.def(py::self == py::self, py::arg("that"));
 
     ////////////////////////////////////////////////////////////////////////
@@ -695,11 +701,14 @@ Construct a node from leftmost index, one-past-rightmost index, and parent.
   :any:`UNDEFINED`).
 :type parent: int | Undefined
 )pbdoc");
-    node.def("__copy__",
-             [](Ukkonen::Node const& that) { return Ukkonen::Node(that); });
+    node.def("__copy__", [](Ukkonen::Node const& that) {
+      return std::make_unique<Ukkonen::Node>(that);
+    });
     node.def(
         "copy",
-        [](Ukkonen::Node const& self) { return Ukkonen::Node(self); },
+        [](Ukkonen::Node const& self) {
+          return std::make_unique<Ukkonen::Node>(self);
+        },
         R"pbdoc(
 :sig=(self: Ukkonen.Node) -> Ukkonen.Node:
 
@@ -767,7 +776,7 @@ Constructs an empty generalised suffix tree.
 )pbdoc");
     thing.def(
         "copy",
-        [](Ukkonen const& self) { return Ukkonen(self); },
+        [](Ukkonen const& self) { return std::make_unique<Ukkonen>(self); },
         R"pbdoc(
 :sig=(self: Ukkonen) -> Ukkonen:
 
@@ -776,7 +785,9 @@ Copy a :any:`Ukkonen` object.
 :returns: A copy.
 :rtype: Ukkonen
 )pbdoc");
-    thing.def("__copy__", [](Ukkonen const& self) { return Ukkonen(self); });
+    thing.def("__copy__", [](Ukkonen const& self) {
+      return std::make_unique<Ukkonen>(self);
+    });
     thing.def("__iter__", [](Ukkonen const& self) {
       return py::make_iterator(self.begin(), self.end());
     });

--- a/src/word-graph.cpp
+++ b/src/word-graph.cpp
@@ -18,6 +18,7 @@
 
 // C++ stl headers....
 #include <cstddef>  // for uint32_t
+#include <memory>   // for make_unique
 #include <vector>   // for vector
 
 // libsemigroups....
@@ -75,10 +76,12 @@ the *out-degree* of the word graph, or any of its nodes.)pbdoc");
     thing.def(py::self >= py::self);
 
     thing.def("__hash__", &WordGraph_::hash_value);
-    thing.def("__copy__", [](WordGraph_ const& wg) { return WordGraph_(wg); });
+    thing.def("__copy__", [](WordGraph_ const& wg) {
+      return std::make_unique<WordGraph_>(wg);
+    });
     thing.def(
         "copy",
-        [](WordGraph_ const& wg) { return WordGraph_(wg); },
+        [](WordGraph_ const& wg) { return std::make_unique<WordGraph_>(wg); },
         R"pbdoc(
 Copy a :any:`WordGraph` object.
 
@@ -1521,10 +1524,11 @@ automata. The input word graphs need not be complete, and the root nodes can
 also be specified.)pbdoc");
     meeter.def("__repr__",
                [](Meeter const& x) { return to_human_readable_repr(x); });
-    meeter.def("__copy__", [](Meeter const& wg) { return Meeter(wg); });
+    meeter.def("__copy__",
+               [](Meeter const& wg) { return std::make_unique<Meeter>(wg); });
     meeter.def(
         "copy",
-        [](Meeter const& wg) { return Meeter(wg); },
+        [](Meeter const& wg) { return std::make_unique<Meeter>(wg); },
         R"pbdoc(
 Copy a :any:`Meeter` object.
 
@@ -1764,10 +1768,11 @@ also be specified.)pbdoc");
     });
     joiner.def(py::init<>(), R"pbdoc(
 Default constructor.)pbdoc");
-    joiner.def("__copy__", [](Joiner const& wg) { return Joiner(wg); });
+    joiner.def("__copy__",
+               [](Joiner const& wg) { return std::make_unique<Joiner>(wg); });
     joiner.def(
         "copy",
-        [](Joiner const& wg) { return Joiner(wg); },
+        [](Joiner const& wg) { return std::make_unique<Joiner>(wg); },
         R"pbdoc(
 Copy a :any:`Joiner` object.
 

--- a/src/word-range.cpp
+++ b/src/word-range.cpp
@@ -22,6 +22,7 @@
 // C++ stl headers....
 #include <initializer_list>  // for initializer_list
 #include <iosfwd>            // for string
+#include <memory>            // for make_unique
 #include <vector>            // for vector
 
 // libsemigroups....
@@ -96,11 +97,12 @@ Example
 )pbdoc");
     thing1.def("__repr__",
                [](WordRange const& wr) { return to_human_readable_repr(wr); });
-    thing1.def("__copy__",
-               [](WordRange const& self) { return WordRange(self); });
+    thing1.def("__copy__", [](WordRange const& self) {
+      return std::make_unique<WordRange>(self);
+    });
     thing1.def(
         "copy",
-        [](WordRange const& self) { return WordRange(self); },
+        [](WordRange const& self) { return std::make_unique<WordRange>(self); },
         R"pbdoc(
 :sig=(self: WordRange) -> WordRange:
 
@@ -500,11 +502,14 @@ Example
     thing2.def("__repr__", [](StringRange const& sr) {
       return to_human_readable_repr(sr);
     });
-    thing2.def("__copy__",
-               [](StringRange const& self) { return StringRange(self); });
+    thing2.def("__copy__", [](StringRange const& self) {
+      return std::make_unique<StringRange>(self);
+    });
     thing2.def(
         "copy",
-        [](StringRange const& self) { return StringRange(self); },
+        [](StringRange const& self) {
+          return std::make_unique<StringRange>(self);
+        },
         R"pbdoc(
 :sig=(self: StringRange) -> StringRange:
 
@@ -903,7 +908,7 @@ Construct a :any:`ToWord` object with the given alphabet.
 )pbdoc");
     thing3.def(
         "copy",
-        [](ToWord const& self) { return ToWord(self); },
+        [](ToWord const& self) { return std::make_unique<ToWord>(self); },
         R"pbdoc(
 :sig=(self: ToWord) -> ToWord:
 
@@ -912,7 +917,9 @@ Copy a :any:`ToWord` object.
 :returns: A copy.
 :rtype: ToWord
 )pbdoc");
-    thing3.def("__copy__", [](ToWord const& self) { return ToWord(self); });
+    thing3.def("__copy__", [](ToWord const& self) {
+      return std::make_unique<ToWord>(self);
+    });
     thing3.def("empty",
                &ToWord::empty,
                R"pbdoc(
@@ -1072,7 +1079,7 @@ Construct a :any:`ToString` object with the given alphabet.
 )pbdoc");
     thing4.def(
         "copy",
-        [](ToString const& self) { return ToString(self); },
+        [](ToString const& self) { return std::make_unique<ToString>(self); },
         R"pbdoc(
 :sig=(self: ToString) -> ToString:
 
@@ -1081,7 +1088,9 @@ Copy a :any:`ToString` object.
 :returns: A copy.
 :rtype: ToString
 )pbdoc");
-    thing4.def("__copy__", [](ToString const& self) { return ToString(self); });
+    thing4.def("__copy__", [](ToString const& self) {
+      return std::make_unique<ToString>(self);
+    });
     thing4.def("alphabet",
                &ToString::alphabet,
                R"pbdoc(

--- a/tests/test_word_graph.py
+++ b/tests/test_word_graph.py
@@ -330,6 +330,23 @@ def test_copy(word_graphs):
     assert copy.copy(wg2) is not wg2
 
 
+@pytest.mark.parametrize("copy_function", [copy.copy, WordGraph.copy])
+def test_copy_independence(copy_function):
+    original = WordGraph(2, 1)
+    original.target(0, 0, 1)
+    duplicate = copy_function(original)
+
+    assert duplicate == original
+    assert duplicate is not original
+    duplicate.target(1, 0, 0)
+    assert original.number_of_edges() == 1
+    assert duplicate.number_of_edges() == 2
+
+    del original
+    assert duplicate.target(0, 0) == 1
+    assert duplicate.target(1, 0) == 0
+
+
 def test_random():
     w = WordGraph.random(5, 5)
     assert w.out_degree() == 5


### PR DESCRIPTION
The remaining `copy()` and `__copy__()` bindings return C++ objects by value, leaving pybind11 to move or copy those temporaries into Python-owned storage. Construct copies directly with `std::make_unique<T>(self)`, following the SchreierSims fix in #467.

Update 98 bindings across 25 C++ files and add the required `<memory>` includes. Add tests for both WordGraph copy entry points that check independent mutation and continued use after the original is deleted. This preserves the Python API and does not add an allocation compared with pybind11's existing by-value conversion.

Fixes #468.

Validation in the `libsemigroups_pybind11_dev` mamba environment:
- Clean C++ extension rebuild, with HPCombi enabled.
- `make check` on this PR branch: 1,509 doctests and 678 pytest tests passed, using the rebuilt extension from the checkout.
- C++ lint, Ruff lint and formatting, and pylint checks passed for the changed files as applicable.
- A small compiled pybind11 check confirmed one copy plus one move for the by-value pattern, versus one copy and no move for direct heap construction. This is not a benchmark of the individual bound types.

AI disclosure: OpenAI Codex authored the code changes, tests, commit, and this PR description at the maintainer's request.