### PR TITLE
docs: link references to external software

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,19 +4,19 @@ Information for developers
 How to compile
 --------------
 
-To build ``libsemigroups_pybind11``, it is first required to have a system
-install of ``libsemigroups``. This is explained in full detail in the
-``libsemigroups``
+To build libsemigroups_pybind11_, it is first required to have a system
+install of libsemigroups_. This is explained in full detail in the
+libsemigroups_
 `documentation <https://libsemigroups.github.io/libsemigroups/md_install.html>`_.
 
-If you only intend to contribute to ``libsemigroups_pybind11``, and not 
-``libsemigroups``, it is sufficient to have the conda version of
-``libsemigroups``.
+If you only intend to contribute to libsemigroups_pybind11_, and not 
+libsemigroups_, it is sufficient to have the conda version of
+libsemigroups_.
 
-If you intend to develop both ``libsemigroups`` and ``libsemigroups_pybind11``,
-it is recommended to build ``libsemigroups`` from the sources. Furthermore, it is
-recommended to install ``libsemigroups`` without ``hpcombi``. Then, with
-``libsemigroups`` installed, the Python bindings can be ``pip`` installed. This
+If you intend to develop both libsemigroups_ and libsemigroups_pybind11_,
+it is recommended to build libsemigroups_ from the sources. Furthermore, it is
+recommended to install libsemigroups_ without ``hpcombi``. Then, with
+libsemigroups_ installed, the Python bindings can be ``pip`` installed. This
 may require the environment variable ``$PKG_CONFIG_PATH`` to be edited.
 
 To create an environment with, ``pip``, correct environment variables, and some
@@ -63,7 +63,7 @@ For a system-wide installation (requires sudo):
 In both cases, ``-j8`` instructs the compiler to use 8 threads (adjust based on your
 system).
 
-To build the Python bindings (with CCache) inside the ``libsemigroups_pybind11``
+To build the Python bindings (with CCache) inside the libsemigroups_pybind11_
 directory:
 
 .. code-block:: console
@@ -73,10 +73,10 @@ directory:
 Building the skeleton of a class
 --------------------------------
 
-If you are adding the bindings for a ``libsemigroups`` class that does not yet
-exist in ``libsemigroups_pybind11``, please consider running the script
+If you are adding the bindings for a libsemigroups_ class that does not yet
+exist in libsemigroups_pybind11_, please consider running the script
 ``generate_pybind11.py`` found in the ``etc/`` directory of
-``libsemigroups``.
+libsemigroups_.
 
 For example:
 
@@ -105,7 +105,7 @@ ________________________________
 A basic guide on how to create bindings for a simple function can be found
 `here <https://pybind11.readthedocs.io/en/stable/basics.html#creating-bindings-for-a-simple-function>`__.
 
-In the ``libsemigroups`` context, to bind the function ``bar`` from the class
+In the libsemigroups_ context, to bind the function ``bar`` from the class
 ``foo`` to the module ``m``:
 
 .. code-block:: cpp
@@ -235,13 +235,13 @@ the code for the bindings of the ``Runner`` class will start with:
   pybind11::class_<Runner, Reporter> runner(m, "Runner");
                            ^^^^^^^^
 
-Making your functions available in ``libsemigroups_pybind11``
+Making your functions available in libsemigroups_pybind11_
 -------------------------------------------------------------
 
 If you followed the instructions in the ``generate_pybind11.py`` script from the
-``libsemigroups`` project, the class you have added bindings for should now be
+libsemigroups_ project, the class you have added bindings for should now be
 available in ``_libsemigroups_pybind11`` (note the leading underscore). How to
-make this available in ``libsemigroups_pybind11`` depends on several factors.
+make this available in libsemigroups_pybind11_ depends on several factors.
 
 A class with no helpers or templates
 ____________________________________
@@ -366,7 +366,7 @@ A sample ``index.rst`` file may look like this:
   =====
 
     This page describes the functionality for the class in
-    ``libsemigroups_pybind11``.
+    libsemigroups_pybind11_.
 
 
   .. toctree::
@@ -413,7 +413,7 @@ _______________________________
 Inside `<docs/source/index.rst>`__, you will find the table of contents tree
 (toctree) for this project. Within that, you will find the names of files
 (without the ``.rst`` extension) of different classifications of structures that
-``libsemigroups_pybind11`` implements, such as congruences, digraphs, semigroups
+libsemigroups_pybind11_ implements, such as congruences, digraphs, semigroups
 and words. Within each of these files, there is another toctree containing
 the paths to the docs of various classes.
 
@@ -497,3 +497,5 @@ whilst contributing are::
   ├── tests/
   │   └── test_class_name.py
   └── CONTRIBUTING.rst (this file!)
+
+.. _libsemigroups_pybind11: https://libsemigroups.github.io/libsemigroups_pybind11/

--- a/docs/source/_static/links.rst
+++ b/docs/source/_static/links.rst
@@ -11,5 +11,7 @@
 .. _Eigen: https://libeigen.gitlab.io/
 .. _pip: https://pip.pypa.io/en/stable/
 .. _mamba: https://mamba.readthedocs.io/en/latest/
-.. _Anaconda: https://www.anaconda.com/docs/getting-started/concepts/anaconda-or-miniconda
-.. _Miniconda: https://www.anaconda.com/docs/getting-started/concepts/anaconda-or-miniconda
+.. _Anaconda: https://www.anaconda.com/docs/main
+.. _Miniconda: https://continuumio-docs.readthedocs-hosted.com/miniconda/
+
+.. |libsemigroups_pybind11| replace:: :doc:`libsemigroups_pybind11 </index>`

--- a/docs/source/_static/links.rst
+++ b/docs/source/_static/links.rst
@@ -4,3 +4,12 @@
 .. _Graphviz: https://www.graphviz.org
 .. _pybind11: https://pybind11.readthedocs.io/en/stable/#
 .. _HPCombi: https://libsemigroups.github.io/HPCombi/
+.. _GAP: https://www.gap-system.org/
+.. _ACE: https://gap-packages.github.io/ace/
+.. _Cython: https://cython.org/
+.. _cppyy: https://cppyy.readthedocs.io/en/latest/
+.. _Eigen: https://libeigen.gitlab.io/
+.. _pip: https://pip.pypa.io/en/stable/
+.. _mamba: https://mamba.readthedocs.io/en/latest/
+.. _Anaconda: https://www.anaconda.com/docs/getting-started/concepts/anaconda-or-miniconda
+.. _Miniconda: https://www.anaconda.com/docs/getting-started/concepts/anaconda-or-miniconda

--- a/docs/source/authors.rst
+++ b/docs/source/authors.rst
@@ -29,7 +29,7 @@ Contributors
 
 - `Nicolas Thiery`_ helped the authors understand the ecosystem for integrating
   C++ code into python, and to some preliminary versions of the python bindings
-  for libsemigroups_ using cython, and cppyy.
+  for libsemigroups_ using Cython_, and cppyy_.
 - Chinmaya Nagpal (chinmaya1011@gmail.com) resolved a great many issues with the
   packaging.
 - James Swent (jws20@st-andrews.ac.uk) contributed several implementations for

--- a/docs/source/changelog-v0.rst
+++ b/docs/source/changelog-v0.rst
@@ -11,13 +11,13 @@ Changelog - version 0
 v0.10.1 (released 29/03/2023)
 -----------------------------
 
-This release increases the required version of ``libsemigroups`` to v2.7.1,
+This release increases the required version of libsemigroups_ to v2.7.1,
 which contains some bug fixes.
 
 v0.10.0 (released 23/03/2023)
 -----------------------------
 
-This is a minor release adding some new functionality from ``libsemigroups``:
+This is a minor release adding some new functionality from libsemigroups_:
 
 - ukkonen: add support for ``Ukkonen`` + helpers by @james-d-mitchell in
   https://github.com/libsemigroups/libsemigroups_pybind11/pull/132
@@ -70,26 +70,26 @@ v0.7.3 (released 07/02/2023)
 ----------------------------
 
 This is a minor version with some improvements and adjustments for forthcoming
-changes in ``libsemigroups``.
+changes in libsemigroups_.
 
 v0.7.2 (released 12/01/2023)
 ----------------------------
 
-This is a minor change related to some forthcoming changes in ``libsemigroups``.
+This is a minor change related to some forthcoming changes in libsemigroups_.
 
 v0.7.1 (released 11/01/2023)
 ----------------------------
 
 This is a very minor release updating the required versions of some dependencies
-to permit the ``libsemigroups_pybind11`` wheel to be built with python 3.11, and
-to adapt for some recent changes in ``libsemigroups``.
+to permit the |libsemigroups_pybind11| wheel to be built with python 3.11, and
+to adapt for some recent changes in libsemigroups_.
 
 v0.7.0 (released 15/12/2022)
 ----------------------------
 
 This release contains a number of improvements and fixes, and adds support for
-the library of finite semigroup and monoid presentations in ``libsemigroups``
-and the ``Stephen`` class from ``libsemigroups``.
+the library of finite semigroup and monoid presentations in libsemigroups_
+and the ``Stephen`` class from libsemigroups_.
 
 - Add functionality for the presentation helper ``replace_word`` by @MTWhyte in
   https://github.com/libsemigroups/libsemigroups_pybind11/pull/84
@@ -104,7 +104,7 @@ v0.6.0 (released 02/12/2022)
 ----------------------------
 
 This release contains a number of improvements and fixes, and adds support for
-the ``Konieczny`` class from ``libsemigroups``.
+the ``Konieczny`` class from libsemigroups_.
 
 - Add missing header include in cong.cpp by @james-d-mitchell in
   https://github.com/libsemigroups/libsemigroups_pybind11/pull/77
@@ -112,7 +112,7 @@ the ``Konieczny`` class from ``libsemigroups``.
   https://github.com/libsemigroups/libsemigroups_pybind11/pull/79
 - Fix string encoding in ``KnuthBendix`` by @james-d-mitchell in
   https://github.com/libsemigroups/libsemigroups_pybind11/pull/82
-- Add support for ``Konieczny`` from ``libsemigroups`` by @james-d-mitchell in
+- Add support for ``Konieczny`` from libsemigroups_ by @james-d-mitchell in
   https://github.com/libsemigroups/libsemigroups_pybind11/pull/80
 - Better ``__repr__`` for ``KnuthBendix`` by @james-d-mitchell in
   https://github.com/libsemigroups/libsemigroups_pybind11/pull/86
@@ -120,7 +120,7 @@ the ``Konieczny`` class from ``libsemigroups``.
 v0.5.0 (released 16/11/2022)
 ----------------------------
 
-This is a minor release adding support for the ``libsemigroups`` class
+This is a minor release adding support for the libsemigroups_ class
 ``Kambites`` for computing small overlap monoids.
 
 v0.4.3 (released 09/11/2022)
@@ -133,12 +133,12 @@ package.
 v0.4.2 (released 28/10/2022)
 ----------------------------
 
-Update for version 2.3.2 of ``libsemigroups`` which contains some bugfixes.
+Update for version 2.3.2 of libsemigroups_ which contains some bugfixes.
 
 v0.4.1 (released 11/10/2022)
 ----------------------------
 
-Update for version 2.3.1 of ``libsemigroups`` which contains some bugfixes in
+Update for version 2.3.1 of libsemigroups_ which contains some bugfixes in
 the ``Sims1`` class, the ``Presentation`` class and its helper functions.
 
 v0.4.0 (released 04/10/2022)
@@ -146,7 +146,7 @@ v0.4.0 (released 04/10/2022)
 
 This is a minor release with a couple of new features added:
 
-- ``libsemigroups`` constants ``POSITIVE_INFINITY``, ``NEGATIVE_INFINITY``, and
+- libsemigroups_ constants ``POSITIVE_INFINITY``, ``NEGATIVE_INFINITY``, and
   ``UNDEFINED`` are properly supported;
 - ``libsemigroups::matrix_helper::pow`` is added as a method for ``__pow__`` for
   some types of matrices (those not defined over a runtime semiring);
@@ -156,7 +156,7 @@ and some minor improvements (the tests now use ``pytest`` exclusively).
 v0.3.0 (released 29/09/2022)
 ----------------------------
 
-This is a minor release adding support for the ``libsemigroups`` class ``Sims1``
+This is a minor release adding support for the libsemigroups_ class ``Sims1``
 for computing low index congruences, and some further minor changes to the
 ``Presentation`` class.
 
@@ -164,7 +164,7 @@ v0.2.2 (released 16/09/2022)
 ----------------------------
 
 A very minor release to futureproof some tests against new versions of
-``libsemigroups``.
+libsemigroups_.
 
 v0.2.1 (released 12/09/2022)
 ----------------------------
@@ -174,7 +174,7 @@ A very minor release trying to fix an issue in the release process.
 v0.2.0 (released 10/09/2022)
 ----------------------------
 
-This is a minor release adding support for the ``libsemigroups`` class template
+This is a minor release adding support for the libsemigroups_ class template
 ``Presentation`` by @MTWhyte and @james-d-mitchell in:
 
 https://github.com/libsemigroups/libsemigroups_pybind11/pull/49
@@ -211,13 +211,13 @@ v0.1.4 (released 12/11/2021)
 ----------------------------
 
 Yet another minor release updating the C++ code for some forthcoming changes in
-``libsemigroups``.
+libsemigroups_.
 
 v0.1.3 (released 11/11/2021)
 ----------------------------
 
 A minor release updating the C++ code for some forthcoming changes in
-``libsemigroups``.
+libsemigroups_.
 
 v0.1.2 (released 11/11/2021)
 ----------------------------
@@ -238,5 +238,5 @@ Some minor issues were resolved and the function ``follow_path`` was added for
 v0.0.0 (released 24/09/2021)
 ----------------------------
 
-First release of the package, some functionality of ``libsemigroups`` is not yet
+First release of the package, some functionality of libsemigroups_ is not yet
 available.

--- a/docs/source/changelog-v1.rst
+++ b/docs/source/changelog-v1.rst
@@ -102,14 +102,14 @@ v1.0.0 (released 12/08/2025)
 ----------------------------
 
 This is a major release that significantly expands the API of
-``libsemigroups_pybind11`` to expose much of the functionality implemented in
+|libsemigroups_pybind11| to expose much of the functionality implemented in
 version 3 of libsemigroups_. The extent of the changes made in this release
 means that it is likely that any code written with earlier versions of
-``libsemigroups_pybind11`` will no longer work.
+|libsemigroups_pybind11| will no longer work.
 
-The structure of ``libsemigroups_pybind11`` is very tightly linked to the
+The structure of |libsemigroups_pybind11| is very tightly linked to the
 structure of libsemigroups_. Therefore, some of the differences between
-v0.10.1 and v1.0.0 of ``libsemigroups_pybind11`` will be related to the
+v0.10.1 and v1.0.0 of |libsemigroups_pybind11| will be related to the
 differences between v2 and v3 of libsemigroups_, such as changes to class names
 and interfaces. These changes can be found in the
 `libsemigroups changelog <https://libsemigroups.github.io/libsemigroups/md_changelog-v3.html>`_.

--- a/docs/source/data-structures/adapters/index.rst
+++ b/docs/source/data-structures/adapters/index.rst
@@ -10,7 +10,7 @@
 Adapters
 ========
 
-This page describes some of the adapters used in ``libsemigroups_pybind11``.
+This page describes some of the adapters used in |libsemigroups_pybind11|.
 These are classes that permit the generic classes in libsemigroups_ to be
 used with arbitrary types, provided that the adapters are implemented for these
 types.

--- a/docs/source/data-structures/constants/index.rst
+++ b/docs/source/data-structures/constants/index.rst
@@ -10,7 +10,7 @@
 Constants
 =========
 
-This page describes some of the constants used in ``libsemigroups_pybind11``.
+This page describes some of the constants used in |libsemigroups_pybind11|.
 
 Constant types
 --------------

--- a/docs/source/data-structures/elements/bipart/index.rst
+++ b/docs/source/data-structures/elements/bipart/index.rst
@@ -9,7 +9,7 @@ Bipartitions and blocks
 =======================
 
 This page describes the functionality for bipartitions and blocks in
-``libsemigroups_pybind11``.
+|libsemigroups_pybind11|.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/data-structures/elements/matrix/index.rst
+++ b/docs/source/data-structures/elements/matrix/index.rst
@@ -11,7 +11,7 @@ Matrix
 ======
 
 This page describes the functionality for matrices over various semirings in
-``libsemigroups_pybind11``.
+|libsemigroups_pybind11|.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/data-structures/elements/pbr/index.rst
+++ b/docs/source/data-structures/elements/pbr/index.rst
@@ -9,7 +9,7 @@ Partitioned binary relations (PBRs)
 ===================================
 
 This page describes the functionality for partitioned binary relations (PBRs) in
-``libsemigroups_pybind11``.
+|libsemigroups_pybind11|.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/data-structures/elements/transformations/index.rst
+++ b/docs/source/data-structures/elements/transformations/index.rst
@@ -9,7 +9,7 @@ Transformations
 ===============
 
 This page describes the functionality for various partial transformations in
-``libsemigroups_pybind11``.
+|libsemigroups_pybind11|.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/data-structures/enums/congruence-kind.rst
+++ b/docs/source/data-structures/enums/congruence-kind.rst
@@ -11,7 +11,7 @@ The congruence_kind enum
 ========================
 
 This page describes the enum class :any:`congruence_kind` in
-``libsemigroups_pybind11`` for representing the whether a congruence is one- or
+|libsemigroups_pybind11| for representing the whether a congruence is one- or
 two-sided.
 
 .. seealso:: 

--- a/docs/source/data-structures/enums/index.rst
+++ b/docs/source/data-structures/enums/index.rst
@@ -9,7 +9,7 @@ Enums
 =====
 
 In this section, we describe the :any:`Enum <enum.Enum>` classes available in
-``libsemigroups_pybind11``.
+|libsemigroups_pybind11|.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/data-structures/enums/matrix-kind.rst
+++ b/docs/source/data-structures/enums/matrix-kind.rst
@@ -11,7 +11,7 @@ The MatrixKind enum
 ===================
 
 This page describes the enum class :any:`MatrixKind` in
-``libsemigroups_pybind11`` for representing the semiring of elements in a
+|libsemigroups_pybind11| for representing the semiring of elements in a
 matrix.
 
 .. seealso::

--- a/docs/source/data-structures/enums/order.rst
+++ b/docs/source/data-structures/enums/order.rst
@@ -10,7 +10,7 @@
 The Order enum
 ===============
 
-This page describes the enum class :any:`Order` in ``libsemigroups_pybind11``
+This page describes the enum class :any:`Order` in |libsemigroups_pybind11|
 for representing the order of words.
 
 Full API

--- a/docs/source/data-structures/enums/paths-algorithm.rst
+++ b/docs/source/data-structures/enums/paths-algorithm.rst
@@ -10,7 +10,7 @@
 The paths.algorithm enum
 ========================
 
-This page describes the enum class :any:`paths.algorithm` in ``libsemigroups_pybind11``.
+This page describes the enum class :any:`paths.algorithm` in |libsemigroups_pybind11|.
 
 Full API
 --------

--- a/docs/source/data-structures/enums/side.rst
+++ b/docs/source/data-structures/enums/side.rst
@@ -11,7 +11,7 @@ The side enum
 =============
 
 This page describes the enum class :py:class:`side` in
-``libsemigroups_pybind11`` for representing whether an action is a left or a
+|libsemigroups_pybind11| for representing whether an action is a left or a
 right action.
 
 .. seealso:: 

--- a/docs/source/data-structures/enums/tril.rst
+++ b/docs/source/data-structures/enums/tril.rst
@@ -11,7 +11,7 @@ The tril enum
 =============
 
 This page describes the enum class :py:class:`tril` in
-``libsemigroups_pybind11`` for representing values that can either be true,
+|libsemigroups_pybind11| for representing values that can either be true,
 false, or not currently known.
 
 Full API

--- a/docs/source/data-structures/hpcombi/index.rst
+++ b/docs/source/data-structures/hpcombi/index.rst
@@ -11,12 +11,12 @@ HPCombi
 =======
 
 This page describes the functionality from `HPCombi`_ available in
-``libsemigroups_pybind11``. This functionality is only available if
+|libsemigroups_pybind11|. This functionality is only available if
 :any:`LIBSEMIGROUPS_HPCOMBI_ENABLED` is ``True``. `HPCombi`_ provides high
 performance (SIMD accelerated) partial transformations, transformations,
 permutations, and partial permutations on up to ``16`` points. The classes
 implementing these element types belong to the ``hpcombi`` subpackage of
-``libsemigroups_pybind11``, and can be used with the ``libsemigroups_pybind11``
+|libsemigroups_pybind11|, and can be used with the |libsemigroups_pybind11|
 classes:
 
 * :any:`FroidurePin`
@@ -29,8 +29,8 @@ Variables
 .. py:attribute:: LIBSEMIGROUPS_HPCOMBI_ENABLED
    :type: bool
 
-   This variable indicates whether or not the version of ``libsemigroups``
-   being used by ``libsemigroups_pybind11`` was compiled with `HPCombi`_
+   This variable indicates whether or not the version of libsemigroups_
+   being used by |libsemigroups_pybind11| was compiled with `HPCombi`_
    enabled.
 
 Classes
@@ -44,6 +44,3 @@ Classes
     ptransf16
     transf16
     vect16
-
-
-.. _HPCombi: https://libsemigroups.github.io/HPCombi/

--- a/docs/source/data-structures/order/index.rst
+++ b/docs/source/data-structures/order/index.rst
@@ -40,7 +40,7 @@ Additionally:
     - :any:`Order`
     - :any:`Alphabet`
 
-The classes and functions in ``libsemigroups_pybind11`` for comparing words
+The classes and functions in |libsemigroups_pybind11| for comparing words
 are described on the following pages:
 
 .. toctree::

--- a/docs/source/data-structures/presentations/index.rst
+++ b/docs/source/data-structures/presentations/index.rst
@@ -9,18 +9,19 @@ Presentations
 =============
 
 The libsemigroups_ C\ **++** library, and hence the
-``libsemigroups_pybind11`` Python package, implements several algorithms for
+|libsemigroups_pybind11| Python package, implements several algorithms for
 computing with finitely presented semigroups and monoids. The implementation of
 the finite presentations on which these algorithms can be run is described
 below.
 
-In ``libsemigroups_pybind11``, a presentation is modelled as a collection of
+In |libsemigroups_pybind11|, a presentation is modelled as a collection of
 *rules*, each of which is a pair of *words* (although these rules are stored as
-a non-nested list with the left- and right-hand sides in the even and odd indexed positions respectively). Each word is made up of *letters*.
-Presently, for any given presentation, all letters must either be of the type
-:any:`str` or :any:`int`. In a presentation where letters are of the type
-:any:`str`, words have the type :any:`str`. In a presentation where letters are
-of the type :any:`int`, words will be lists of :any:`int` types.
+a non-nested list with the left- and right-hand sides in the even and odd
+indexed positions respectively). Each word is made up of *letters*. Presently,
+for any given presentation, all letters must either be of the type :any:`str`
+or :any:`int`. In a presentation where letters are of the type :any:`str`,
+words have the type :any:`str`. In a presentation where letters are of the type
+:any:`int`, words will be lists of :any:`int` types.
 
 **Once a presentation is constructed, the type of its letters and words cannot
 be changed.**
@@ -29,7 +30,7 @@ In what follows, we will use the pseudo-types ``Letter`` and ``Word`` instead of
 ``str | int`` and ``str | list[int]`` to further indicate that two types of
 letters and words cannot be interchanged once a presentation is constructed.
 
-The classes and modules in ``libsemigroups_pybind11`` for finitely presented
+The classes and modules in |libsemigroups_pybind11| for finitely presented
 semigroups and monoids are:
 
 

--- a/docs/source/data-structures/presentations/obvinf.rst
+++ b/docs/source/data-structures/presentations/obvinf.rst
@@ -11,7 +11,7 @@ Obviously infinite
 ==================
 
 This page collects the documentation for the functionality in
-``libsemigroups_pybind11`` for checking if a finitely presented semigroup or
+|libsemigroups_pybind11| for checking if a finitely presented semigroup or
 monoid is obviously infinite.
 
 The functions below implement a number of checks for whether or not a finitely

--- a/docs/source/data-structures/presentations/to-alphabet.rst
+++ b/docs/source/data-structures/presentations/to-alphabet.rst
@@ -11,13 +11,13 @@ Converting to an Alphabet
 =========================
 
 This page contains documentation relating to converting
-``libsemigroups_pybind11`` objects into :any:`Alphabet` instances using the
+|libsemigroups_pybind11| objects into :any:`Alphabet` instances using the
 :any:`to` function.
 
 .. seealso::
 
     :doc:`/data-structures/to-function` for an overview of possible conversions
-    between ``libsemigroups_pybind11`` types.
+    between |libsemigroups_pybind11| types.
 
 Various uses
 ------------

--- a/docs/source/data-structures/presentations/to-inverse-present.rst
+++ b/docs/source/data-structures/presentations/to-inverse-present.rst
@@ -11,13 +11,13 @@ Converting to an InversePresentation
 ====================================
 
 This page contains documentation relating to converting
-``libsemigroups_pybind11`` objects into :any:`InversePresentation` instances
+|libsemigroups_pybind11| objects into :any:`InversePresentation` instances
 using the :any:`to` function.
 
 .. seealso::
 
     :doc:`/data-structures/to-function` for an overview of possible conversions
-    between ``libsemigroups_pybind11`` types.
+    between |libsemigroups_pybind11| types.
 
 Various uses
 ------------

--- a/docs/source/data-structures/presentations/to-present.rst
+++ b/docs/source/data-structures/presentations/to-present.rst
@@ -11,13 +11,13 @@ Converting to a Presentation
 ============================
 
 This page contains documentation relating to converting
-``libsemigroups_pybind11`` objects into :any:`Presentation` instances using the
+|libsemigroups_pybind11| objects into :any:`Presentation` instances using the
 :any:`to` function.
 
 .. seealso::
 
     :doc:`/data-structures/to-function` for an overview of possible conversions
-    between ``libsemigroups_pybind11`` types.
+    between |libsemigroups_pybind11| types.
 
 Various uses
 ------------

--- a/docs/source/data-structures/suffix-trees/index.rst
+++ b/docs/source/data-structures/suffix-trees/index.rst
@@ -9,7 +9,7 @@ Suffix Trees
 ============
 
 This page describes the functionality related to Ukkonen's algorithm and
-generalised suffix trees in ``libsemigroups_pybind11``.
+generalised suffix trees in |libsemigroups_pybind11|.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/data-structures/suffix-trees/ukkonen-helpers.rst
+++ b/docs/source/data-structures/suffix-trees/ukkonen-helpers.rst
@@ -14,7 +14,7 @@ manipulating :any:`Ukkonen` objects.
 Contents
 --------
 
-In ``libsemigroups_pybind11``:
+In |libsemigroups_pybind11|:
 
 .. currentmodule:: libsemigroups_pybind11.ukkonen
 

--- a/docs/source/data-structures/to-function.rst
+++ b/docs/source/data-structures/to-function.rst
@@ -15,14 +15,14 @@ The ``to`` function
 ===================
 
 This page contains links to the documentation of the uses of the function
-:any:`to` for converting from one type of object in ``libsemigroups_pybind11``
+:any:`to` for converting from one type of object in |libsemigroups_pybind11|
 to another type. These mostly only apply to the types implementing the main
-algorithms in ``libsemigroups_pybind11``.
+algorithms in |libsemigroups_pybind11|.
 
 For example, to convert a :any:`ToddCoxeter` object ``tc`` to a
 :any:`FroidurePin` object, you can simply do ``to(tc, rtype=(FroidurePin,))``.
 
-A summary of the possible conversions available in ``libsemigroups_pybind11`` of
+A summary of the possible conversions available in |libsemigroups_pybind11| of
 ``to(FromType, rtype=(ToType,))`` are given below, where the rows correspond to
 ``ToType`` and the columns to ``FromType``:
 

--- a/docs/source/data-structures/visualisation/index.rst
+++ b/docs/source/data-structures/visualisation/index.rst
@@ -9,8 +9,8 @@ Visualisation
 =============
 
 This page contains links to the classes and functions in
-``libsemigroups_pybind11`` for visualising instances of some of the other
-objects implemented in ``libsemigroups_pybind11``.
+|libsemigroups_pybind11| for visualising instances of some of the other
+objects implemented in |libsemigroups_pybind11|.
 
 The class :any:`Dot` facilitates the creation and rendering of graph
 descriptions in the DOT_ language of Graphviz_ graph drawing software.

--- a/docs/source/data-structures/word-graph/index.rst
+++ b/docs/source/data-structures/word-graph/index.rst
@@ -11,7 +11,7 @@ Word Graphs
 ===========
 
 This page contains links to the documentation for the parts of
-``libsemigroups_pybind11`` for word graphs.
+|libsemigroups_pybind11| for word graphs.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/data-structures/words/index.rst
+++ b/docs/source/data-structures/words/index.rst
@@ -10,7 +10,7 @@
 Words
 =====
 
-This pages contains links to documentation in ``libsemigroups_pybind11`` for:
+This pages contains links to documentation in |libsemigroups_pybind11| for:
 
 - generating words and strings in a given range and in a certain order:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@
 What is libsemigroups_?
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Before explaining what ``libsemigroups_pybind11`` is, it is first necessary to
+Before explaining what |libsemigroups_pybind11| is, it is first necessary to
 explain `libsemigroups`_. `libsemigroups`_ is a C++17 library containing
 implementations of several algorithms for computing finite, and finitely
 presented, semigroups and monoids. The main algorithms implemented in
@@ -67,33 +67,33 @@ presented, semigroups and monoids. The main algorithms implemented in
 .. _Semigroupe 2.01: https://www.irif.fr/~jep/Logiciels/Semigroupe2.0/semigroupe2.html
 .. _Jean-Eric Pin: https://www.irif.fr/~jep/
 
-What is ``libsemigroups_pybind11``?
+What is |libsemigroups_pybind11|?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``libsemigroups_pybind11`` is a package for Python 3.9+ exposing much
+|libsemigroups_pybind11| is a package for Python 3.9+ exposing much
 (but not all) of the functionality of libsemigroups_. It is built with the help
 of the excellent library pybind11_, for which we are very grateful. A more
 detailed description of the structure of this package, along with some
 associated quirks, is described on the
 :doc:`exceptions page<libsemigroups-error>`.
 
-The development version of ``libsemigroups_pybind11`` is available on github_,
+The development version of |libsemigroups_pybind11| is available on github_,
 and some related projects are here_.
 
 
 .. _github: https://github.com/libsemigroups/libsemigroups_pybind11
 .. _here: https://github.com/libsemigroups
 
-How to install ``libsemigroups_pybind11``
+How to install |libsemigroups_pybind11|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To see the different ways ``libsemigroups_pybind11`` can be installed, see the
+To see the different ways |libsemigroups_pybind11| can be installed, see the
 :doc:`installation page<install>`.
 
 Issues
 ~~~~~~
 
-If you find any problems with ``libsemigroups_pybind11``, or have any
+If you find any problems with |libsemigroups_pybind11|, or have any
 suggestions for features that you'd like to see, please use the
 `issue tracker`_.
 
@@ -101,7 +101,7 @@ Acknowledgements
 ~~~~~~~~~~~~~~~~
 
 In addition to `libsemigroups`_, there are several excellent projects that are
-utilised in the development of ``libsemigroups_pybind11``, specifically:
+utilised in the development of |libsemigroups_pybind11|, specifically:
 
 * `codespell`_, `cpplint`_, `Pylint`_ and `Ruff`_ for code quality;
 * `Graphviz`_ for graph visualisation;

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -11,7 +11,7 @@ Installation
 Installing with pip
 -------------------
 
-It's possible to install ``libsemigroups_pybind11`` using ``pip`` by doing one
+It's possible to install ``libsemigroups_pybind11`` using pip_ by doing one
 of the following (depending on your system and setup):
 
 .. highlight:: console
@@ -33,7 +33,7 @@ of the following (depending on your system and setup):
 Installing with mamba
 ---------------------
 
-This installation method assumes that you have anaconda or miniconda installed.
+This installation method assumes that you have Anaconda_ or Miniconda_ installed.
 See the `getting started`_ and `miniconda download page`_ on the conda_ website.
 
 .. _conda: https://conda.io/
@@ -42,8 +42,8 @@ See the `getting started`_ and `miniconda download page`_ on the conda_ website.
 
 .. _miniconda download page: https://conda.io/miniconda.html
 
-It might be a good idea to create and activate a conda/mamba environment to contain
-the installation of the ``libsemigroups_pybind11``:
+It might be a good idea to create and activate a conda_ or mamba_ environment to
+contain the installation of the ``libsemigroups_pybind11``:
 
 ::
 
@@ -70,12 +70,12 @@ From the sources
 ----------------
 
 Before installing ``libsemigroups_pybind11`` from its sources, you should first
-perform a system install of the C++ library ``libsemigroups``. For information
+perform a system install of the C++ library libsemigroups_. For information
 about how to do this, see the `libsemigroups installation guide
 <https://libsemigroups.github.io/libsemigroups/md_install.html>`_.
 
-Assuming that you have ``libsemigroups`` installed, you can install
-``libsemigroups_pybind11`` with ``pip``:
+Assuming that you have libsemigroups_ installed, you can install
+``libsemigroups_pybind11`` with pip_:
 
 ::
 
@@ -83,7 +83,7 @@ Assuming that you have ``libsemigroups`` installed, you can install
     $ cd libsemigroups_pybind11
     $ pip install .
 
-or with the ``uv`` pip-compatible interface
+or with the uv_ pip-compatible interface
 
 ::
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -11,7 +11,7 @@ Installation
 Installing with pip
 -------------------
 
-It's possible to install ``libsemigroups_pybind11`` using pip_ by doing one
+It's possible to install |libsemigroups_pybind11| using pip_ by doing one
 of the following (depending on your system and setup):
 
 .. highlight:: console
@@ -33,17 +33,21 @@ of the following (depending on your system and setup):
 Installing with mamba
 ---------------------
 
-This installation method assumes that you have Anaconda_ or Miniconda_ installed.
-See the `getting started`_ and `miniconda download page`_ on the conda_ website.
+This installation method assumes that you have Mamba_, Micromamba_, Anaconda_,
+or Miniconda_ installed. See the `getting started`_ and `miniconda download
+page`_ on the conda_ website.
+
+
+.. _Micromamba: https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html
 
 .. _conda: https://conda.io/
 
-.. _getting started: http://bit.ly/33B0Vfs
+.. _getting started: https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html
 
-.. _miniconda download page: https://conda.io/miniconda.html
+.. _miniconda download page: https://www.anaconda.com/docs/getting-started/miniconda/install/
 
 It might be a good idea to create and activate a conda_ or mamba_ environment to
-contain the installation of the ``libsemigroups_pybind11``:
+contain the installation of the |libsemigroups_pybind11|:
 
 ::
 
@@ -69,13 +73,13 @@ For more information, see uv's guide on `managing dependencies`_.
 From the sources
 ----------------
 
-Before installing ``libsemigroups_pybind11`` from its sources, you should first
+Before installing |libsemigroups_pybind11| from its sources, you should first
 perform a system install of the C++ library libsemigroups_. For information
 about how to do this, see the `libsemigroups installation guide
 <https://libsemigroups.github.io/libsemigroups/md_install.html>`_.
 
 Assuming that you have libsemigroups_ installed, you can install
-``libsemigroups_pybind11`` with pip_:
+|libsemigroups_pybind11| with pip_:
 
 ::
 
@@ -94,7 +98,7 @@ or with the uv_ pip-compatible interface
 From a release archive
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To build ``libsemigroups_pybind11`` from a release archive:
+To build |libsemigroups_pybind11| from a release archive:
 
 .. Unfortunately, text replacement doesn't work inside of code blocks, so it is
    necessary to update the version number below manually.
@@ -124,6 +128,6 @@ instead of running ``make doc`` (which is precisely what ``make doc`` does).
 Issues
 ------
 
-If you find any problems with ``libsemigroups_pybind11``, or have any
+If you find any problems with |libsemigroups_pybind11|, or have any
 suggestions for features that you'd like to see, please use the
 `issue tracker`_.

--- a/docs/source/libsemigroups-error.rst
+++ b/docs/source/libsemigroups-error.rst
@@ -10,14 +10,14 @@
 Exceptions
 ==========
 
-This page describes the custom error type used in ``libsemigroups_pybind11``,
+This page describes the custom error type used in |libsemigroups_pybind11|,
 namely :any:`LibsemigroupsError`, and related functions. Other built-in
 exceptions, such as :any:`ValueError` and :any:`TypeError`, may also be raised
 in this project. See the
 `Python documentation <https://docs.python.org/3/library/exceptions.html>`_
 for further details.
 
-The Python module ``libsemigroups_pybind11`` was designed to mirror the C++
+The Python module |libsemigroups_pybind11| was designed to mirror the C++
 library libsemigroups_ as closely as possible, whilst navigating the
 fundamental difference between Python and C++. This is done with the help of 
 pybind11_.
@@ -25,21 +25,21 @@ pybind11_.
 For various implementational reasons (mostly related to Python's lack of an
 analogue for C++'s templating system), the Python code exposed by ``pybind11``
 is less streamlined and concise than the C++ library. To try and address this,
-the authors of ``libsemigroups_pybind11`` have further wrapped the Python code
+the authors of |libsemigroups_pybind11| have further wrapped the Python code
 produced by ``pybind11`` to make the Python and C++ user experience as similar
 as possible.
 
 The Python bindings of the libsemigroups_ code produced by ``pybind11``
 reside in an intermediate module called ``_libsemigroups_pybind11`` (note the
 leading underscore), and the public-facing nicely wrapped code resides in this
-module — ``libsemigroups_pybind11``.
+module — |libsemigroups_pybind11|.
 
-Should this impact the way you, the user, use ``libsemigroups_pybind11``? For
-the most part, no. It should be possible to use ``libsemigroups_pybind11`` in
+Should this impact the way you, the user, use |libsemigroups_pybind11|? For
+the most part, no. It should be possible to use |libsemigroups_pybind11| in
 the ways documented on this site without the knowledge that
 ``_libsemigroups_pybind11`` even exists. The notable exceptions to this relate
 to type names and error messages. A lot of the code in
-``libsemigroups_pybind11`` has been imported from ``_libsemigroups_pybind11``,
+|libsemigroups_pybind11| has been imported from ``_libsemigroups_pybind11``,
 and this is visible in qualified type names. For example:
 
 .. doctest:: python
@@ -50,7 +50,7 @@ and this is visible in qualified type names. For example:
 
 Additionally, some functions or classes in the ``_libsemigroups_pybind11``
 module have additional prefixes and suffixes relative to their
-``libsemigroups_pybind11`` counterpart. These usually relate to the module that
+|libsemigroups_pybind11| counterpart. These usually relate to the module that
 the function or class is contained within or a type the function or class is
 defined upon. These may appear in error messages. For example:
 
@@ -67,7 +67,7 @@ defined upon. These may appear in error messages. For example:
     <BLANKLINE>
     Invoked with: <AhoCorasick with 1 node>, False
 
-The authors of ``libsemigroups_pybind11`` have gone to a lot of effort to try
+The authors of |libsemigroups_pybind11| have gone to a lot of effort to try
 and make error messages clear, specific and intelligible; however, if you
 encounter any errors with unclear messages, please let us know on the 
 `issue tracker`_.
@@ -79,7 +79,7 @@ Full API
     :show-inheritance:
 
     This is the main type of exception raised by the custom data-structures and
-    algorithms of ``libsemigroups_pybind11``. It is raised when the underlying
+    algorithms of |libsemigroups_pybind11|. It is raised when the underlying
     C++ code from libsemigroups_ raises a ``LibsemigroupsException``.
 
     .. doctest:: python

--- a/docs/source/main-algorithms/action/index.rst
+++ b/docs/source/main-algorithms/action/index.rst
@@ -11,7 +11,7 @@ Actions
 =======
 
 This page contains links to the documentation for the classes in
-``libsemigroups_pybind11`` for semigroup actions.
+|libsemigroups_pybind11| for semigroup actions.
 
 .. seealso:: 
 

--- a/docs/source/main-algorithms/congruence/to-cong.rst
+++ b/docs/source/main-algorithms/congruence/to-cong.rst
@@ -11,13 +11,13 @@ Converting to a Congruence
 ==========================
 
 This page contains documentation relating to converting
-``libsemigroups_pybind11`` objects into :any:`Congruence` instances using the
+|libsemigroups_pybind11| objects into :any:`Congruence` instances using the
 :any:`to` function.
 
 .. seealso::
 
     :doc:`/data-structures/to-function` for an overview of possible conversions
-    between ``libsemigroups_pybind11`` types.
+    between |libsemigroups_pybind11| types.
 
 Various uses
 ------------

--- a/docs/source/main-algorithms/core-classes/index.rst
+++ b/docs/source/main-algorithms/core-classes/index.rst
@@ -8,7 +8,7 @@
 Core classes
 ============
 
-Many of the classes in ``libsemigroups_pybind11`` implement algorithms, and
+Many of the classes in |libsemigroups_pybind11| implement algorithms, and
 hence are runnable. During the running of these algorithms, it is often
 desirable to report the state of the algorithm. Therefore, the classes
 :any:`Runner` and :any:`Reporter` exist to provide common functions to many

--- a/docs/source/main-algorithms/froidure-pin/index.rst
+++ b/docs/source/main-algorithms/froidure-pin/index.rst
@@ -8,7 +8,7 @@
 Froidure-Pin
 ============
 
-The functionality in ``libsemigroups_pybind11`` related to the Froidure-Pin
+The functionality in |libsemigroups_pybind11| related to the Froidure-Pin
 algorithm :cite:`Froidure1997aa` is contained in the class and the helper
 functions below.
 

--- a/docs/source/main-algorithms/froidure-pin/to-froidure-pin.rst
+++ b/docs/source/main-algorithms/froidure-pin/to-froidure-pin.rst
@@ -11,13 +11,13 @@ Converting to a FroidurePin
 ===========================
 
 This page contains documentation relating to converting
-``libsemigroups_pybind11`` objects into :any:`FroidurePin` instances using the
+|libsemigroups_pybind11| objects into :any:`FroidurePin` instances using the
 :any:`to` function.
 
 .. seealso::
 
     :doc:`/data-structures/to-function` for an overview of possible conversions
-    between ``libsemigroups_pybind11`` types.
+    between |libsemigroups_pybind11| types.
 
 Various uses
 ------------

--- a/docs/source/main-algorithms/kambites/index.rst
+++ b/docs/source/main-algorithms/kambites/index.rst
@@ -9,7 +9,7 @@ Kambites
 ========
 
 On this page there are links to the documentation for the algorithms in
-``libsemigroups_pybind11`` for small overlap monoids by Mark Kambites and the
+|libsemigroups_pybind11| for small overlap monoids by Mark Kambites and the
 authors of libsemigroups_; see :cite:`Kambites2009aa`,
 :cite:`Kambites2009ab`, and :cite:`Mitchell2021aa`.
 

--- a/docs/source/main-algorithms/knuth-bendix/index.rst
+++ b/docs/source/main-algorithms/knuth-bendix/index.rst
@@ -9,7 +9,7 @@ Knuth-Bendix
 ============
 
 This page describes the functionality for the Knuth-Bendix procedure in
-``libsemigroups_pybind11``.
+|libsemigroups_pybind11|.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/main-algorithms/knuth-bendix/to-knuth-bendix.rst
+++ b/docs/source/main-algorithms/knuth-bendix/to-knuth-bendix.rst
@@ -11,13 +11,13 @@ Converting to a KnuthBendix
 ===========================
 
 This page contains documentation relating to converting
-``libsemigroups_pybind11`` objects into :any:`KnuthBendix` instances using the
+|libsemigroups_pybind11| objects into :any:`KnuthBendix` instances using the
 :any:`to` function.
 
 .. seealso::
 
     :doc:`/data-structures/to-function` for an overview of possible conversions
-    between ``libsemigroups_pybind11`` types.
+    between |libsemigroups_pybind11| types.
 
 Various uses
 ------------

--- a/docs/source/main-algorithms/konieczny/index.rst
+++ b/docs/source/main-algorithms/konieczny/index.rst
@@ -9,7 +9,7 @@ Konieczny
 =========
 
 This page describes the functionality for Konieczny's algorithm in
-``libsemigroups_pybind11``.
+|libsemigroups_pybind11|.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/main-algorithms/low-index/classes/index.rst
+++ b/docs/source/main-algorithms/low-index/classes/index.rst
@@ -12,7 +12,7 @@ Classes for low-index congruences
 
 On this page we describe the functionality relating to the Sims's low-index
 congruence algorithm for semigroups and monoids that is available in
-``libsemigroups_pybind11``.
+|libsemigroups_pybind11|.
 
 .. doctest::
 

--- a/docs/source/main-algorithms/low-index/index.rst
+++ b/docs/source/main-algorithms/low-index/index.rst
@@ -10,7 +10,7 @@
 Low-index congruences
 =====================
 
-This page contains links to the functionality in ``libsemigroups_pybind11``
+This page contains links to the functionality in |libsemigroups_pybind11|
 related to the low-index congruences algorithm from
 :cite:`Anagnostopoulou-Merkouri2023aa` for finitely presented semigroups.
 

--- a/docs/source/main-algorithms/radoszewski-rytter/index.rst
+++ b/docs/source/main-algorithms/radoszewski-rytter/index.rst
@@ -10,7 +10,7 @@
 Radoszewski-Rytter
 ==================
 
-``libsemigroups_pybind11`` contains an implementation of the Radoszewski-Rytter
+|libsemigroups_pybind11| contains an implementation of the Radoszewski-Rytter
 Algorithm :cite:`Radoszewski2010aa` for testing equivalence of words in free
 bands.
 

--- a/docs/source/main-algorithms/schreier-sims/index.rst
+++ b/docs/source/main-algorithms/schreier-sims/index.rst
@@ -10,7 +10,7 @@ Schreier-Sims
 
 This page describes the functionality related to the Schreier-Sims algorithm for
 computing a stabilizer chain of a permutation group in
-``libsemigroups_pybind11``.
+|libsemigroups_pybind11|.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/main-algorithms/stephen/index.rst
+++ b/docs/source/main-algorithms/stephen/index.rst
@@ -8,7 +8,7 @@
 Stephen
 =======
 
-This page contains links to the functionality in ``libsemigroups_pybind11``
+This page contains links to the functionality in |libsemigroups_pybind11|
 related to Stephen's procedure :cite:`Stephen1987aa` for finitely presented
 semigroups.
 

--- a/docs/source/main-algorithms/todd-coxeter/to-todd-coxeter.rst
+++ b/docs/source/main-algorithms/todd-coxeter/to-todd-coxeter.rst
@@ -11,13 +11,13 @@ Converting to a ToddCoxeter
 ===========================
 
 This page contains documentation relating to converting
-``libsemigroups_pybind11`` objects into :any:`ToddCoxeter` instances using the
+|libsemigroups_pybind11| objects into :any:`ToddCoxeter` instances using the
 :any:`to` function.
 
 .. seealso::
 
     :doc:`/data-structures/to-function` for an overview of possible conversions
-    between ``libsemigroups_pybind11`` types.
+    between |libsemigroups_pybind11| types.
 
 Various uses
 ------------

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -59,9 +59,9 @@ namespace libsemigroups {
 Class for determining the action of a semigroup or monoid on a set.
 
 This page contains details of the :any:`Action` class in
-``libsemigroups_pybind11`` for finding actions of semigroups, monoids, or
+|libsemigroups_pybind11| for finding actions of semigroups, monoids, or
 groups, on sets.  The notion of an "action" in the context of
-``libsemigroups_pybind11`` is analogous to the notion of an orbit of a group.
+|libsemigroups_pybind11| is analogous to the notion of an orbit of a group.
 
 You are unlikely to want to use :any:`Action` directly, but rather via the more
 convenient aliases :any:`RightAction` and :any:`LeftAction`.

--- a/src/bmat8.cpp
+++ b/src/bmat8.cpp
@@ -97,7 +97,7 @@ the submodule ``bmat8``.
    BMat8(0)
 
 :any:`BMat8` objects can be used with the following algorithms in
-``libsemigroups_pybind11``
+|libsemigroups_pybind11|
 
 * :any:`FroidurePin`
 * :any:`Konieczny`

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -37,7 +37,7 @@ namespace libsemigroups {
 The type of :any:`UNDEFINED`.
 
 This class is the type of the constant value :any:`UNDEFINED`, and appears as
-such in type annotations in ``libsemigroups_pybind11``.
+such in type annotations in |libsemigroups_pybind11|.
 )pbdoc")
         .def("__repr__",
              [](Undefined const& val) -> std::string { return "UNDEFINED"; })
@@ -65,7 +65,7 @@ such in type annotations in ``libsemigroups_pybind11``.
 The type of :any:`POSITIVE_INFINITY`.
 
 This class is the type of the constant value :any:`POSITIVE_INFINITY`, and appears as
-such in type annotations in ``libsemigroups_pybind11``.
+such in type annotations in |libsemigroups_pybind11|.
 )pbdoc")
         .def("__repr__",
              [](PositiveInfinity const& val) -> std::string {
@@ -105,7 +105,7 @@ such in type annotations in ``libsemigroups_pybind11``.
 The type of :any:`NEGATIVE_INFINITY`.
 
 This class is the type of the constant value :any:`NEGATIVE_INFINITY`, and appears as
-such in type annotations in ``libsemigroups_pybind11``.
+such in type annotations in |libsemigroups_pybind11|.
 )pbdoc")
         .def("__repr__",
              [](NegativeInfinity const& val) -> std::string {
@@ -136,7 +136,7 @@ such in type annotations in ``libsemigroups_pybind11``.
 The type of :any:`LIMIT_MAX`.
 
 This class is the type of the constant value :any:`LIMIT_MAX`, and appears as
-such in type annotations in ``libsemigroups_pybind11``.
+such in type annotations in |libsemigroups_pybind11|.
 )pbdoc")
         .def("__repr__",
              [](LimitMax const& val) -> std::string { return "LIMIT_MAX"; })

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -81,8 +81,8 @@ namespace libsemigroups {
           R"pbdoc(
 Return whether :any:`LibsemigroupsError` messages have a C++ prefix.
 
-Since ``libsemigroups_pybind11`` is built on top of the C++ library
-libsemigroups_, many of the errors thrown in ``libsemigroups_pybind11``
+Since |libsemigroups_pybind11| is built on top of the C++ library
+libsemigroups_, many of the errors thrown in |libsemigroups_pybind11|
 emanate from C++. This function returns whether :any:`LibsemigroupsError`
 messages contain a prefix that indicates which C++ function raised the
 exception.
@@ -97,8 +97,8 @@ exception.
           R"pbdoc(
 Specify whether :any:`LibsemigroupsError` messages have a C++ prefix.
 
-Since ``libsemigroups_pybind11`` is built on top of the C++ library
-libsemigroups_, many of the errors thrown in ``libsemigroups_pybind11``
+Since |libsemigroups_pybind11| is built on top of the C++ library
+libsemigroups_, many of the errors thrown in |libsemigroups_pybind11|
 emanate from C++. This function specifies whether :any:`LibsemigroupsError`
 messages should contain a prefix that indicates which C++ function raised the
 exception. By default, this information is not included.

--- a/src/hpcombi.cpp
+++ b/src/hpcombi.cpp
@@ -56,7 +56,7 @@ namespace HPCombi {
 Vector of ``16`` bytes, with some SIMD optimized methods, superclass of
 :any:`hpcombi.Transf16`. Entries in :any:`Vect16` must be integers in the range :math:`[0, 256)`.
 
-This class belongs to the ``hpcombi`` subpackage of ``libsemigroups_pybind11``.
+This class belongs to the ``hpcombi`` subpackage of |libsemigroups_pybind11|.
 
 The functionality described on this page is only available if
 :any:`LIBSEMIGROUPS_HPCOMBI_ENABLED` is ``True``.
@@ -557,7 +557,7 @@ SIMD accelerated class :any:`PTransf16` representing partial transformations on
 up to ``16`` points. Partial means it might not be defined everywhere.
 Undefined images are encoded as ``255``.
 
-This class belongs to the ``hpcombi`` subpackage of ``libsemigroups_pybind11``.
+This class belongs to the ``hpcombi`` subpackage of |libsemigroups_pybind11|.
 
 The functionality described on this page is only available if
 :any:`LIBSEMIGROUPS_HPCOMBI_ENABLED` is ``True``.
@@ -722,7 +722,7 @@ transformation (i.e. no image value is larger than ``15``) on the values
 
 .. note::
   It should not be possible to create an invalid :any:`PTransf16` in
-  ``libsemigroups_pybind11``, and this function is only included for
+  |libsemigroups_pybind11|, and this function is only included for
   completeness.
 
 .. doctest::
@@ -1214,7 +1214,7 @@ Class representing transformations.
 SIMD accelerated class :any:`Transf16` representing transformations on
 up to ``16`` points.
 
-This class belongs to the ``hpcombi`` subpackage of ``libsemigroups_pybind11``.
+This class belongs to the ``hpcombi`` subpackage of |libsemigroups_pybind11|.
 
 The functionality described on this page is only available if
 :any:`LIBSEMIGROUPS_HPCOMBI_ENABLED` is ``True``.
@@ -1356,7 +1356,7 @@ transformation (i.e. no image value is larger than ``15``) on the values
 
 .. note::
   It should not be possible to create an invalid :any:`Transf16` in
-  ``libsemigroups_pybind11``, and this function is only included for
+  |libsemigroups_pybind11|, and this function is only included for
   completeness.
 
 .. doctest::
@@ -1405,7 +1405,7 @@ Class representing permutations.
 SIMD accelerated class :any:`Perm16` representing permutations on
 up to ``16`` points.
 
-This class belongs to the ``hpcombi`` subpackage of ``libsemigroups_pybind11``.
+This class belongs to the ``hpcombi`` subpackage of |libsemigroups_pybind11|.
 
 The functionality described on this page is only available if
 :any:`LIBSEMIGROUPS_HPCOMBI_ENABLED` is ``True``.
@@ -2162,7 +2162,7 @@ SIMD accelerated class :any:`PPerm16` representing partial permutations on
 up to ``16`` points (i.e. bijections between subsets of :math:`\{0\dots 15\}`).
 Undefined images are encoded as ``255``.
 
-This class belongs to the ``hpcombi`` subpackage of ``libsemigroups_pybind11``.
+This class belongs to the ``hpcombi`` subpackage of |libsemigroups_pybind11|.
 
 The functionality described on this page is only available if
 :any:`LIBSEMIGROUPS_HPCOMBI_ENABLED` is ``True``.

--- a/src/knuth-bendix.cpp
+++ b/src/knuth-bendix.cpp
@@ -48,9 +48,10 @@ namespace libsemigroups {
 Class containing an implementation of the Knuth-Bendix Algorithm.
 
 On this page we describe the functionality relating to the Knuth-Bendix
-algorithm for semigroups and monoids in ``libsemigroups_pybind11``. This page
+algorithm for semigroups and monoids in |libsemigroups_pybind11|. This page
 contains details of the member functions of the class
-:any:`KnuthBendix`. This class is used to represent a `string rewriting system <https://w.wiki/9Re>`_
+:any:`KnuthBendix`. This class is used to represent a
+`string rewriting system <https://w.wiki/9Re>`_
 defining a 1- or 2-sided congruence on a finitely presented monoid or
 semigroup.
 

--- a/src/libsemigroups_pybind11/hpcombi.py
+++ b/src/libsemigroups_pybind11/hpcombi.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 
-"""This page contains the documentation for the HPCombi functionality exposed
+"""This page contains the documentation for the HPCombi_ functionality exposed
 in ``libsemigroups_pybind11``.
 """
 

--- a/src/libsemigroups_pybind11/hpcombi.py
+++ b/src/libsemigroups_pybind11/hpcombi.py
@@ -4,8 +4,10 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 
-"""This page contains the documentation for the HPCombi_ functionality exposed
-in ``libsemigroups_pybind11``.
+"""This page contains the documentation for the HPCombi functionality exposed
+in libsemigroups_pybind11.
+
+NOTE: This string isn't included in the doc, so there's no point in editing it.
 """
 
 from _libsemigroups_pybind11 import LIBSEMIGROUPS_HPCOMBI_ENABLED

--- a/src/libsemigroups_pybind11/to.py
+++ b/src/libsemigroups_pybind11/to.py
@@ -5,7 +5,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 
 """Subpackage containing the :any:`to` function for converting
-``libsemigroups_pybind11`` objects from one type to another.
+|libsemigroups_pybind11| objects from one type to another.
 """
 
 from typing import _GenericAlias
@@ -119,7 +119,7 @@ _VALID_TYPES_STRING = "\n    * " + "\n    * ".join(_VALID_TYPES) + "\n"
 
 
 def to(*args, rtype: tuple):
-    """Convert from one type of ``libsemigroups_pybind11`` object to another.
+    """Convert from one type of |libsemigroups_pybind11| object to another.
 
     This function converts the the arguments specified in *args* to object of
     type *rtype*.

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -168,7 +168,7 @@ namespace libsemigroups {
                             py_type.c_str(),
                             R"pbdoc(
 This page contains the documentation for functionality in
-``libsemigroups_pybind11`` for matrices.
+|libsemigroups_pybind11| for matrices.
 
 Matrices over various semirings can be constructed using the class
 :py:class:`Matrix`. These internal types are optimised in
@@ -179,7 +179,7 @@ submodule :any:`libsemigroups_pybind11.matrix`.
 
 .. warning::
 
-    The entries in a ``libsemigroups_pybind11`` matrix are stored internally as
+    The entries in a |libsemigroups_pybind11| matrix are stored internally as
     64-bit signed integers, and there are no checks that the multiplication does
     not overflow.
 

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -859,7 +859,7 @@ Compare two words using recursive-path ordering.
 This function compares two objects using the recursive-path comparison, based on
 the description in :cite:`Jantzen2012aa` (Definition 1.2.14, page 24) and
 :cite:`Dershowitz1982aa` (Definition 5, page 289). The following definition is
-used in ``libsemigroups_pybind11``.
+used in |libsemigroups_pybind11|.
 
 If :math:`u, v\ in X ^ {*}`, then :math:`u < v` if and only if one of the
 following conditions holds:

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -597,8 +597,8 @@ This function returns the number of paths in the word graph *wg* starting at
   is the out-degree of the word graph.
 
 .. note::
-    If ``libsemigroups`` is compiled with the flag ``--enable-eigen``, then
-    this function makes use of the `Eigen` library for linear algebra (see
+    If libsemigroups_ is compiled with the flag ``--enable-eigen``, then
+    this function makes use of the Eigen_ library for linear algebra (see
     :cite:`Guennebaud2010aa`).
 
 .. warning::
@@ -665,8 +665,8 @@ length in a given range.
     preceding algorithms and then applies that.
 
 .. note::
-    If ``libsemigroups`` is compiled with the flag ``--enable-eigen``, then
-    this function makes use of the `Eigen` library for linear algebra (see
+    If libsemigroups_ is compiled with the flag ``--enable-eigen``, then
+    this function makes use of the Eigen_ library for linear algebra (see
     :cite:`Guennebaud2010aa`).
 
 .. warning::
@@ -742,8 +742,8 @@ and ending at node *target* with length in a given range.
     preceding algorithms and then applies that.
 
 .. note::
-    If ``libsemigroups`` is compiled with the flag ``--enable-eigen``, then
-    this function makes use of the `Eigen` library for linear algebra (see
+    If libsemigroups_ is compiled with the flag ``--enable-eigen``, then
+    this function makes use of the Eigen_ library for linear algebra (see
     :cite:`Guennebaud2010aa`).
 
 .. warning::

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -59,7 +59,7 @@ Presentations for semigroups and monoids.
 
 This class can be used to construct presentations for semigroups or monoids
 and is intended to be used as the input to other algorithms in
-``libsemigroups_pybind11``. The idea is to provide a shallow wrapper around a
+|libsemigroups_pybind11|. The idea is to provide a shallow wrapper around a
 collection of words of type :ref:`Word<pseudo_word_type_class>`. We refer to
 this list of words as the *rules* of the presentation. The :any:`Presentation`
 class also provides some checks that the rules really define a presentation,
@@ -2024,7 +2024,7 @@ An implementation of inverse presentations for semigroups or monoids.
 
 This class can be used to construct inverse presentations for semigroups or
 monoids and is intended to be used as the input to other algorithms in
-``libsemigroups_pybind11``.
+|libsemigroups_pybind11|.
 
 This class inherits from :any:`Presentation`.)pbdoc");
       thing.def("__repr__", [](InversePresentation_ const& p) -> std::string {

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -1640,19 +1640,19 @@ modified version.
 :sig=(p: Presentation, var_name: str) -> str:
 :only-document-once:
 
-Return the code that would create *p* in GAP.
+Return the code that would create *p* in GAP_.
 
-This function returns the string of GAP code that could be used to create an
-object with the same alphabet and rules as *p* in GAP. Presentations in GAP
+This function returns the string of GAP_ code that could be used to create an
+object with the same alphabet and rules as *p* in GAP_. Presentations in GAP_
 are created by taking quotients of free semigroups or monoids.
 
 :param p: the presentation.
 :type p: Presentation
 
-:param var_name: the name of the variable to be used in GAP (defaults to ``"S"``).
+:param var_name: the name of the variable to be used in GAP_ (defaults to ``"S"``).
 :type var_name: str
 
-:returns: The GAP string.
+:returns: The GAP_ string.
 :rtype: str
 
 .. doctest::
@@ -1676,15 +1676,15 @@ are created by taking quotients of free semigroups or monoids.
           R"pbdoc(
 :sig=(p: Presentation) -> str:
 :only-document-once:
-Returns a string containing the content of an ACE input file.
+Returns a string containing the content of an ACE_ input file.
 
-This function returns the string of ACE :cite:`Havas1999iy` input that could be
+This function returns the string of ACE_ :cite:`Havas1999iy` input that could be
 used to create an object with the same alphabet and rules as *p*.
 
 :param p: the presentation.
 :type p: Presentation
 
-:returns: The ACE string.
+:returns: The ACE_ string.
 :rtype: str
 
 :raises LibsemigroupsError: if ``p.alphabet()`` contains any duplicate letters.
@@ -1694,11 +1694,11 @@ used to create an object with the same alphabet and rules as *p*.
 
 .. note::
 
-  ACE assumes that presentations are group presentations, where the the alphabet
+  ACE_ assumes that presentations are group presentations, where the the alphabet
   consists of lowercase letters, and inverses correspond to the equivalent
-  uppercase letters. Therefore, a valid ACE presentation may not be a valid
+  uppercase letters. Therefore, a valid ACE_ presentation may not be a valid
   ``libsemigroups_pybdind11`` :any:`Presentation`; for example, it is possible
-  for relations in an ACE presentation to contain uppercase letters that are not
+  for relations in an ACE_ presentation to contain uppercase letters that are not
   explicitly named as generators, as long as their lowercase counterparts are
   listed as generators.
 )pbdoc");

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -32,7 +32,7 @@ namespace libsemigroups {
                             "ReportGuard",
                             R"pbdoc(
 Objects of this type can be used to enable printing of some information
-during various computations in ``libsemigroups_pybind11``. Reporting
+during various computations in |libsemigroups_pybind11|. Reporting
 is enabled (or not) at construction time, and disabled when the
 :any:`ReportGuard` goes out of scope.
       )pbdoc")

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -117,7 +117,7 @@ The time between the given point and now.
    datetime.timedelta
 
 .. deprecated:: 1.1
-  This will be removed from ``libsemigroups_pybind11`` in v2. Instead, use
+  This will be removed from |libsemigroups_pybind11| in v2. Instead, use
   ``datetime.datetime.now() - t``.
 
 .. seealso::
@@ -313,7 +313,7 @@ last report, as set by one of:
    datetime.datetime
 
 .. deprecated:: 1.1
-  This will be removed from ``libsemigroups_pybind11`` in v2.
+  This will be removed from |libsemigroups_pybind11| in v2.
 )pbdoc");
     thing.def("reset_last_report",
               &Reporter::reset_last_report,
@@ -372,7 +372,7 @@ run at the outermost level.
                                        R"pbdoc(
 Abstract class for derived [#sortof]_ classes that run an algorithm.
 
-Many of the classes in ``libsemigroups_pybind11`` implementing the algorithms,
+Many of the classes in |libsemigroups_pybind11| implementing the algorithms,
 that are the reason for the existence of this package, are derived from
 :any:`Runner`. The :any:`Runner` class exists to collect various common tasks
 required by such a derived class with a possibly long-running :any:`Runner.run`. These

--- a/src/todd-coxeter-impl.cpp
+++ b/src/todd-coxeter-impl.cpp
@@ -69,32 +69,32 @@ The valid values are:
 .. py:attribute:: strategy.hlt
   :value: <strategy.hlt: 0>
 
-  This value indicates that the HLT (Hazelgrove-Leech-Trotter) strategy should be used. This is analogous to ACE's R-style.
+  This value indicates that the HLT (Hazelgrove-Leech-Trotter) strategy should be used. This is analogous to the R-style of ACE_.
 
 .. py:attribute:: strategy.felsch
   :value: <strategy.felsch: 1>
 
-  This value indicates that the Felsch strategy should be used. This is analogous to ACE's C-style.
+  This value indicates that the Felsch strategy should be used. This is analogous to the C-style of ACE_.
 
 .. py:attribute:: strategy.CR
   :value: <strategy.CR: 2>
 
-  This strategy is meant to mimic the ACE strategy of the same name. The Felsch strategy is run until at least :any:`f_defs` nodes are defined, then the HLT strategy is run until at least :any:`hlt_defs` divided by :math:`N` nodes have been defined, where :math:`N` is the sum of the lengths of the words in the presentation and generating pairs. These steps are repeated until the enumeration terminates.
+  This strategy is meant to mimic the ACE_ strategy of the same name. The Felsch strategy is run until at least :any:`f_defs` nodes are defined, then the HLT strategy is run until at least :any:`hlt_defs` divided by :math:`N` nodes have been defined, where :math:`N` is the sum of the lengths of the words in the presentation and generating pairs. These steps are repeated until the enumeration terminates.
 
 .. py:attribute:: strategy.R_over_C
   :value: <strategy.R_over_C: 3>
 
-  This strategy is meant to mimic the ACE strategy R/C. The HLT strategy is run until the first lookahead is triggered (when the number of nodes active is at least :any:`lookahead_next`). A full lookahead is then performed, and then the CR strategy is used.
+  This strategy is meant to mimic the ACE_ strategy R/C. The HLT strategy is run until the first lookahead is triggered (when the number of nodes active is at least :any:`lookahead_next`). A full lookahead is then performed, and then the CR strategy is used.
 
 .. py:attribute:: strategy.Cr
   :value: <strategy.Cr: 4>
 
-  This strategy is meant to mimic the ACE strategy Cr. The Felsch strategy is run until at least :any:`f_defs` new nodes have been defined, then the HLT strategy is run until at least :any:`hlt_defs` divided by :math:`N` nodes have been defined, where :math:`N` is the sum of the lengths of the words in the presentation and generating pairs. Then the Felsch strategy is run.
+  This strategy is meant to mimic the ACE_ strategy Cr. The Felsch strategy is run until at least :any:`f_defs` new nodes have been defined, then the HLT strategy is run until at least :any:`hlt_defs` divided by :math:`N` nodes have been defined, where :math:`N` is the sum of the lengths of the words in the presentation and generating pairs. Then the Felsch strategy is run.
 
 .. py:attribute:: strategy.Rc
   :value: <strategy.Rc: 5>
 
-  This strategy is meant to mimic the ACE strategy Rc. The HLT strategy is run until at least :any:`hlt_defs` divided by :math:`N` new nodes have been defined (where :math:`N` is the sum of the lengths of the words in the presentation and generating pairs). The Felsch strategy is then run until at least :any:`f_defs` new nodes are defined, and then the HLT strategy is run.
+  This strategy is meant to mimic the ACE_ strategy Rc. The HLT strategy is run until at least :any:`hlt_defs` divided by :math:`N` new nodes have been defined (where :math:`N` is the sum of the lengths of the words in the presentation and generating pairs). The Felsch strategy is then run until at least :any:`f_defs` new nodes are defined, and then the HLT strategy is run.
 
 
 
@@ -504,9 +504,9 @@ The default value of this setting is :any:`def_version.two`.
         R"pbdoc(
 :sig=(self: ToddCoxeter) -> int:
 
-Get the number of Felsch style definitions in ACE strategies. This
+Get the number of Felsch style definitions in ACE_ strategies. This
 function returns the approximate number of Felsch style definitions in each
-phase of the `ACE <https://staff.itee.uq.edu.au/havas/>`_ style
+phase of the ACE_ style
 strategies:
 
 - :any:`strategy.CR`;
@@ -534,10 +534,10 @@ The default value of this setting is ``10 ** 5``.
         R"pbdoc(
 :sig=(self: ToddCoxeter, val: int) -> ToddCoxeter:
 
-Set the number of Felsch style definitions in ACE strategies.
+Set the number of Felsch style definitions in ACE_ strategies.
 
 This function can be used to set the approximate number of Felsch style definitions
-in each phase of the `ACE <https://staff.itee.uq.edu.au/havas/>`_
+in each phase of the ACE_
 style strategies:
 
 * :any:`strategy.CR`;
@@ -565,9 +565,9 @@ The default value of this setting is ``10 ** 5``.
         R"pbdoc(
 :sig=(self: ToddCoxeter) -> int:
 
-Get the number of HLT style definitions in ACE strategies. This function
+Get the number of HLT style definitions in ACE_ strategies. This function
 returns the approximate number of HLT style definitions in each phase of
-the `ACE <https://staff.itee.uq.edu.au/havas/>`_ style strategies:
+the ACE_ style strategies:
 
 -  :any:`strategy.CR`;
 -  :any:`strategy.R_over_C`;
@@ -594,10 +594,10 @@ The default value of this setting is ``10 ** 5``.
         R"pbdoc(
 :sig=(self: ToddCoxeter, val: int) -> ToddCoxeter:
 
-Set the number of HLT style definitions in ACE strategies.
+Set the number of HLT style definitions in ACE_ strategies.
 
 This function can be used to set the approximate number of HLT style
-definitions in each phase of the `ACE <https://staff.itee.uq.edu.au/havas/>`_
+definitions in each phase of the ACE_
 style strategies:
 
 *  :any:`strategy.CR`;

--- a/src/todd-coxeter.cpp
+++ b/src/todd-coxeter.cpp
@@ -483,10 +483,10 @@ Neumann for the trivial group:
   tc = ToddCoxeter(congruence_kind.twosided, p)
 
 Then running *tc* will simply grow the underlying word graph until
-your computer runs out of memory. The authors of ``libsemigroups`` were
+your computer runs out of memory. The authors of libsemigroups_ were
 not able to find any combination of the many settings for
 :any:`ToddCoxeter` where running *tc* returned an answer. We also tried
-with GAP and ACE but neither of these seemed able to return an answer
+with GAP_ and ACE_ but neither of these seemed able to return an answer
 either. But doing the following:
 
 .. code-block:: python
@@ -953,10 +953,10 @@ Neumann for the trivial group:
   tc = ToddCoxeter(congruence_kind.twosided, p)
 
 Then running *tc* will simply grow the underlying word graph until
-your computer runs out of memory. The authors of ``libsemigroups`` were
+your computer runs out of memory. The authors of libsemigroups_ were
 not able to find any combination of the many settings for
 :any:`ToddCoxeter` where running *tc* returned an answer. We also tried
-with GAP and ACE but neither of these seemed able to return an answer
+with GAP_ and ACE_ but neither of these seemed able to return an answer
 either. But doing the following:
 
 .. code-block:: python

--- a/src/word-graph.cpp
+++ b/src/word-graph.cpp
@@ -687,7 +687,7 @@ Returns the adjacency matrix of a word graph.
 
 This function returns the adjacency matrix of the word graph *wg*. The
 type of the returned matrix depends on whether or not libsemigroups_ is
-compiled with `eigen <http://eigen.tuxfamily.org/>`_ enabled. The returned
+compiled with Eigen_ enabled. The returned
 matrix has the number of edges with source ``s`` and target ``t`` in the
 ``(s, t)``-entry.
 

--- a/src/word-range.cpp
+++ b/src/word-range.cpp
@@ -1409,7 +1409,7 @@ expression, and has the following behaviour:
   ''
 
 .. deprecated:: 1.5
-  This will be removed from ``libsemigroups_pybind11`` in v2. Instead, use
+  This will be removed from |libsemigroups_pybind11| in v2. Instead, use
   :any:`words.parse`.
 )pbdoc");
 


### PR DESCRIPTION
Software names in the documentation and binding docstrings often appear as plain text. Add shared link targets for GAP, ACE, Eigen, Cython, cppyy, pip, mamba, Anaconda and Miniconda, and use them at the existing mentions. Also link missing HPCombi and libsemigroups references and standardise the existing ACE and Eigen destinations.

Validation: rebuilt the extension on this branch; the full Sphinx HTML build passed with warnings treated as errors; shared external link checks, rendered HTML link checks, docstring indentation checks and `git diff --check` passed.

AI disclosure: OpenAI Codex authored these changes and this PR description at James Mitchell's request. The commit records Codex as author and James Mitchell as committer.

Fixes #464.