### PR TITLE
Fix Sims deadlocks with Python callbacks in worker threads

### DIFF
--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -700,8 +700,11 @@ constructed from the presentation *p*.
                     doc_type)
             .c_str());
 
+    // Worker threads may call Python predicates or pruners. Release the GIL
+    // while waiting for them; pybind11's std::function wrapper reacquires it.
     thing.def("number_of_congruences",
               &Thing::number_of_congruences,
+              py::call_guard<py::gil_scoped_release>(),
               py::arg("n"),
               fmt::format(R"pbdoc(
 :sig=(self: {0}, n: int) -> int:
@@ -734,6 +737,7 @@ This function exists to:
 
     thing.def("for_each",
               &Thing::for_each,
+              py::call_guard<py::gil_scoped_release>(),
               py::arg("n"),
               py::arg("pred"),
               fmt::format(R"pbdoc(
@@ -769,6 +773,7 @@ most *n* classes. This function exists to:
 
     thing.def("find_if",
               &Thing::find_if,
+              py::call_guard<py::gil_scoped_release>(),
               py::arg("n"),
               py::arg("pred"),
               fmt::format(R"pbdoc(

--- a/tests/test_sims_threads.py
+++ b/tests/test_sims_threads.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, J. D. Mitchell
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+
+"""Regression tests for Python callbacks in Sims worker threads (issue #417)."""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.quick
+@pytest.mark.parametrize("sims_class", ["Sims1", "Sims2"])
+@pytest.mark.parametrize("threads", [1, 2])
+@pytest.mark.parametrize("with_pruner", [False, True])
+@pytest.mark.parametrize("operation", ["find_match", "find_no_match", "for_each", "count"])
+def test_sims_python_callbacks(sims_class, threads, with_pruner, operation):
+    """Callbacks must run without deadlocking the calling Python thread."""
+    # A Python thread timeout cannot stop C++ code holding the GIL. Run in a
+    # subprocess so a regression fails this test instead of hanging pytest.
+    code = textwrap.dedent(f"""
+        from libsemigroups_pybind11 import (
+            Presentation, ReportGuard, {sims_class}, word_graph,
+        )
+
+        report = ReportGuard(False)
+        p = Presentation([0])
+        p.contains_empty_word(True)
+        p.rules = [[0, 0, 0, 0], []]
+        s = {sims_class}(p).number_of_threads({threads})
+        if {threads} == 2 and s.number_of_threads() < 2:
+            raise SystemExit(77)
+
+        pruned = []
+        def pruner(wg):
+            pruned.append(wg.number_of_nodes())
+            return True
+
+        if {with_pruner}:
+            s.add_pruner(pruner)
+
+        visited = []
+        def callback(wg):
+            size = word_graph.number_of_nodes_reachable_from(wg, 0)
+            visited.append(size)
+            return size == 4 and {operation!r} == "find_match"
+
+        if {operation!r} == "count":
+            assert s.number_of_congruences(4) == 3
+        elif {operation!r} == "for_each":
+            s.for_each(4, callback)
+            assert sorted(visited) == [1, 2, 4]
+        elif {operation!r} == "find_match":
+            result = s.find_if(4, callback)
+            assert word_graph.number_of_nodes_reachable_from(result, 0) == 4
+            assert 4 in visited
+        else:
+            result = s.find_if(4, callback)
+            assert result.number_of_nodes() == 0
+            assert sorted(visited) == [1, 2, 4]
+
+        if {with_pruner}:
+            assert pruned
+    """)
+    # Preserve the test runner's import paths, including editable/source builds.
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=env,
+        check=False,
+    )
+    if result.returncode == 77:
+        pytest.skip("requires support for at least two Sims worker threads")
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
Calling `Sims1.find_if` or `Sims2.find_if` with multiple threads and a Python predicate deadlocks: the calling thread holds the GIL while waiting for workers that need it to copy or invoke the callback. `for_each` has the same problem, as does `number_of_congruences` when a Python pruner is installed.

Release the GIL around these three C++ operations using `py::call_guard<py::gil_scoped_release>()`. Pybind11's `std::function` wrapper reacquires it when accessing Python. The shared bindings apply the fix to both Sims classes.

Add 32 subprocess regression cases covering both classes, one and two threads, searches with and without a match, iteration, counting, and optional Python pruners. Subprocess timeouts make a deadlock fail the test instead of hanging pytest.

Validation in the `libsemigroups_pybind11_dev` mamba environment:

- Confirmed that the two-thread regression test times out before the fix.
- Rebuilt the extension and ran `pytest tests/test_sims_threads.py tests/test_sims.py -q`: **52 passed**.
- The original issue example completes with two threads in approximately 2.96 seconds, finding a graph with 35 reachable nodes.
- Ruff checks and formatting, Pylint, and `git diff --check` passed for the changes.

A separate libsemigroups limitation remains: Python exceptions escaping a worker thread terminate the process. This was reproduced separately and requires catching worker exceptions and propagating them back to the calling thread.

Fixes #417.

AI disclosure: Codex (OpenAI) investigated the issue, authored the implementation and regression tests, ran the validation, and drafted this PR description. The commit records Codex as author and James Mitchell as committer.
