### PR TITLE
Label merged fixes as resolved-pending-release

### DIFF
--- a/.github/workflows/label-fixed-issues.yml
+++ b/.github/workflows/label-fixed-issues.yml
@@ -1,0 +1,57 @@
+name: Label issues after merge
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  pull-requests: read
+  issues: write
+
+jobs:
+  label:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const label = "fix merged";
+            const { owner, repo } = context.repo;
+            let cursor = null;
+
+            do {
+              const result = await github.graphql(`
+                query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      closingIssuesReferences(first: 100, after: $cursor) {
+                        nodes {
+                          number
+                          repository { nameWithOwner }
+                        }
+                        pageInfo { hasNextPage endCursor }
+                      }
+                    }
+                  }
+                }
+              `, {
+                owner, repo,
+                number: context.payload.pull_request.number,
+                cursor,
+              });
+
+              const issues = result.repository.pullRequest.closingIssuesReferences;
+              for (const issue of issues.nodes) {
+                if (issue.repository.nameWithOwner !== `${owner}/${repo}`) continue;
+                await github.rest.issues.addLabels({
+                  owner, repo,
+                  issue_number: issue.number,
+                  labels: [label],
+                });
+                core.info(`Added "${label}" to #${issue.number}`);
+              }
+
+              cursor = issues.pageInfo.hasNextPage ? issues.pageInfo.endCursor : null;
+            } while (cursor);

--- a/.github/workflows/label-fixed-issues.yml
+++ b/.github/workflows/label-fixed-issues.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/github-script@v9
         with:
           script: |
-            const label = "fix merged";
+            const label = "resolved-pending-release";
             const { owner, repo } = context.repo;
             let cursor = null;
 


### PR DESCRIPTION
When a pull request is merged into `main`, add the `resolved-pending-release` label to its linked issues in this repository. This lets maintainers track merged fixes awaiting release while leaving issue closure to verification or release, provided automatic issue closure is disabled in repository settings.

The workflow uses `pull_request_target: closed` with a merged check, queries GitHub's linked issues with pagination, and skips issues in other repositories. It uses the built-in token with `pull-requests: read` and `issues: write`; no PR code is checked out or executed.

Keep issues linked through closing references such as `Fixes #417` or through the Development sidebar. The workflow uses the repository's `resolved-pending-release` label. This workflow handles future merge events and does not backfill earlier merges.

Validation:

- Parsed the YAML and checked the event filters, merged condition, and token permissions.
- Checked the embedded JavaScript syntax with Node.js.
- Ran local tests with mocked GitHub responses covering no linked issues, adding the label, pagination, and filtering issues from other repositories.
- Verified the updated label is exactly `resolved-pending-release`.
- Git whitespace checks passed.

The workflow has not yet run on GitHub Actions.

AI disclosure: Codex (OpenAI) drafted the workflow and PR description and performed the local validation. James Mitchell added the workflow locally and specified the label name. The commits record Codex as author and James Mitchell as committer.