### PR TITLE
build(deps): update soupsieve to 2.8.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -932,11 +932,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update Soup Sieve from 2.8 to 2.8.4 in `uv.lock` to address [Dependabot alert #43](https://github.com/libsemigroups/libsemigroups_pybind11/security/dependabot/43), [GHSA-2wc2-fm75-p42x / CVE-2026-49476](https://github.com/facelessuser/soupsieve/security/advisories/GHSA-2wc2-fm75-p42x). Versions through 2.8.3 are affected by memory exhaustion when compiling large comma-separated CSS selector lists.

Soup Sieve is pulled in by Beautiful Soup in the documentation dependencies. The lockfile now matches the patched version already pinned in `requirements.txt`; its wheel and source archive metadata were regenerated with `uv lock --upgrade-package soupsieve==2.8.4`.

Validation:

- `uv lock --check --offline` and `git diff --check` passed.
- Installed the locked documentation dependencies in a temporary Python 3.14 environment with `uv sync --locked --extra docs --no-dev --no-install-project`.
- Beautiful Soup/Soup Sieve CSS selector smoke checks passed.
- A minimal Sphinx HTML build with warnings treated as errors, the RTD theme, copybutton, and bibtex extensions passed; generated HTML selection also passed.
- Confirmed that Soup Sieve is the only changed package and all other lockfile metadata is unchanged.

The full project test suite and full documentation build were not run locally.
