### PR TITLE
Preserve generic arguments and quote strings in conversion type names

### DIFF
--- a/src/libsemigroups_pybind11/to.py
+++ b/src/libsemigroups_pybind11/to.py
@@ -8,7 +8,7 @@
 |libsemigroups_pybind11| objects from one type to another.
 """
 
-from typing import _GenericAlias
+from typing import get_origin as _get_origin
 
 from _libsemigroups_pybind11 import (
     Order as _Order,
@@ -56,7 +56,6 @@ from .presentation import InversePresentation as _InversePresentation, Presentat
 from .todd_coxeter import ToddCoxeter as _ToddCoxeter
 
 
-# FIXME this function converts list[int] -> list, but shouldn't
 def _nice_name(type_list):
     """Convert an iterable of type-like things into a string"""
     single_element = False
@@ -67,7 +66,7 @@ def _nice_name(type_list):
     for t in type_list:
         if isinstance(t, str):
             out.append(t)
-        elif isinstance(t, _GenericAlias):
+        elif _get_origin(t) is not None:
             out.append(str(t))
         elif hasattr(t, "__name__"):
             out.append(t.__name__)

--- a/src/libsemigroups_pybind11/to.py
+++ b/src/libsemigroups_pybind11/to.py
@@ -65,7 +65,7 @@ def _nice_name(type_list):
     out = []
     for t in type_list:
         if isinstance(t, str):
-            out.append(t)
+            out.append(f'"{t}"')
         elif _get_origin(t) is not None:
             out.append(str(t))
         elif hasattr(t, "__name__"):

--- a/src/libsemigroups_pybind11/to.py
+++ b/src/libsemigroups_pybind11/to.py
@@ -8,7 +8,8 @@
 |libsemigroups_pybind11| objects from one type to another.
 """
 
-from typing import get_origin as _get_origin
+from collections.abc import Iterator as _Iterator
+from typing import Any as _Any, get_origin as _get_origin
 
 from _libsemigroups_pybind11 import (
     Order as _Order,
@@ -56,14 +57,14 @@ from .presentation import InversePresentation as _InversePresentation, Presentat
 from .todd_coxeter import ToddCoxeter as _ToddCoxeter
 
 
-def _nice_name(type_list):
-    """Convert an iterable of type-like things into a string"""
-    single_element = False
-    if not isinstance(type_list, tuple):
-        single_element = True
-        type_list = [type_list]
+def _nice_name(types: _Iterator[_Any]) -> str:
+    """Convert an iterable of things into a string"""
+    not_tuple = False
+    if not isinstance(types, tuple):
+        not_tuple = True
+        types = (types,)
     out = []
-    for t in type_list:
+    for t in types:
         if isinstance(t, str):
             out.append(f'"{t}"')
         elif _get_origin(t) is not None:
@@ -72,8 +73,10 @@ def _nice_name(type_list):
             out.append(t.__name__)
         else:
             out.append(str(t))
-    if single_element:
+    if not_tuple:
         return out[0]
+    if len(types) == 1:
+        out[0] += ","
     return f"({', '.join(out)})"
 
 

--- a/tests/test_to.py
+++ b/tests/test_to.py
@@ -1082,13 +1082,13 @@ def test_to_Congruence_010():
         (list, "list"),
         (str, "str"),
         (Presentation, "Presentation"),
-        ("Set", "Set"),
+        ("Set", '"Set"'),
         (Order.lenlex, "Order.lenlex"),
         ((Presentation,), "(Presentation)"),
         ((Presentation, list[int]), "(Presentation, list[int])"),
         (
             (KnuthBendix, list[int], "Trie", Order.lenlex),
-            "(KnuthBendix, list[int], Trie, Order.lenlex)",
+            '(KnuthBendix, list[int], "Trie", Order.lenlex)',
         ),
     ],
 )
@@ -1102,7 +1102,7 @@ def test_to_invalid_word_type():
 
     message = str(exc_info.value)
     assert "\n    * (Presentation, list[int])\n" in message
-    assert "\n    * (KnuthBendix, list[int], Trie, Order.lenlex)\n" in message
+    assert '\n    * (KnuthBendix, list[int], "Trie", Order.lenlex)\n' in message
     assert message.endswith("but found: (Presentation, list[str])")
 
 

--- a/tests/test_to.py
+++ b/tests/test_to.py
@@ -8,6 +8,8 @@
 
 """This module contains some tests for the to function."""
 
+from typing import Literal
+
 import pytest
 
 # TODO(1) be good to remove the imports from _libsemigroups_pybind11, but
@@ -50,6 +52,7 @@ from libsemigroups_pybind11 import (
     to,
 )
 from libsemigroups_pybind11.detail.cxx_wrapper import to_cxx
+from libsemigroups_pybind11.to import _nice_name
 
 ###############################################################################
 # Helper functions
@@ -1066,6 +1069,41 @@ def test_to_Congruence_010():
 ###############################################################################
 # Exceptions
 ###############################################################################
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (list[int], "list[int]"),
+        (list[str], "list[str]"),
+        (dict[str, list[int]], "dict[str, list[int]]"),
+        (tuple[int, ...], "tuple[int, ...]"),
+        (Literal[1, 2], "typing.Literal[1, 2]"),
+        (list, "list"),
+        (str, "str"),
+        (Presentation, "Presentation"),
+        ("Set", "Set"),
+        (Order.lenlex, "Order.lenlex"),
+        ((Presentation,), "(Presentation)"),
+        ((Presentation, list[int]), "(Presentation, list[int])"),
+        (
+            (KnuthBendix, list[int], "Trie", Order.lenlex),
+            "(KnuthBendix, list[int], Trie, Order.lenlex)",
+        ),
+    ],
+)
+def test_nice_name(value, expected):
+    assert _nice_name(value) == expected
+
+
+def test_to_invalid_word_type():
+    with pytest.raises(TypeError) as exc_info:
+        to(sample_froidure_pin(), rtype=(Presentation, list[str]))
+
+    message = str(exc_info.value)
+    assert "\n    * (Presentation, list[int])\n" in message
+    assert "\n    * (KnuthBendix, list[int], Trie, Order.lenlex)\n" in message
+    assert message.endswith("but found: (Presentation, list[str])")
 
 
 def test_to_999():

--- a/tests/test_to.py
+++ b/tests/test_to.py
@@ -1084,7 +1084,7 @@ def test_to_Congruence_010():
         (Presentation, "Presentation"),
         ("Set", '"Set"'),
         (Order.lenlex, "Order.lenlex"),
-        ((Presentation,), "(Presentation)"),
+        ((Presentation,), "(Presentation,)"),
         ((Presentation, list[int]), "(Presentation, list[int])"),
         (
             (KnuthBendix, list[int], "Trie", Order.lenlex),


### PR DESCRIPTION
`to()` error messages lose generic type arguments, making `list[int]` and `list[str]` both appear as `list`. Use `typing.get_origin` to preserve these arguments, and wrap string options in double quotes so return types appear as `(KnuthBendix, list[int], "Trie", Order.lenlex)`.

Add regression coverage for generic types, existing name formatting, and the valid and rejected types shown in conversion errors.

Fixes #450.

Validation: all 77 conversion tests pass; Ruff lint, Ruff formatting, Pylint, and `git diff --check` pass.
