### PR TITLE
build(deps): update idna to 3.15

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -262,11 +262,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update `idna` from 3.11 to 3.15 in `uv.lock` to address [Dependabot alert #40](https://github.com/libsemigroups/libsemigroups_pybind11/security/dependabot/40) ([CVE-2026-45409](https://github.com/kjd/idna/security/advisories/GHSA-65pc-fj4g-8rjx)). The patched version rejects overlong inputs before expensive validation, including per-label conversions and codec support.

`idna` is a transitive documentation dependency through Sphinx and Requests. Only its locked version and artifact metadata change; `requirements.txt` already pins 3.15.

Validation:

- `uv lock --check --offline` passed; a structural comparison confirmed that only the `idna` package entry changed.
- `uv sync --locked --extra docs --no-install-project` succeeded in a temporary virtual environment.
- Smoke checks passed for normal Unicode IDNA conversion, rejection of both advisory payloads by `idna.encode` and `idna.alabel`, Requests Unicode-hostname preparation, and Sphinx import.
- Both pre-commit hook stages ran on `uv.lock`: codespell passed; other hooks skipped because no applicable files changed.
- Full pytest and documentation builds were not run for this lockfile-only change.

AI disclosure: OpenAI Codex investigated the alert, prepared the dependency update and PR description, and ran the validation checks.