### PR TITLE
build(deps): update pytest to 9.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ docs = [
 # This list should contain any package used to test the package.
 # These should not be aggressively pinned to allow the package to be tested
 # on as many different systems as possible.
-test = ["pytest>=8.4.2"]
+test = ["pytest>=9.1.1"]
 
 [dependency-groups]
 # This list should contain any package used in the development of

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ pygments==2.20.0
     # via
     #   pytest
     #   sphinx
-pytest==8.4.2
+pytest==9.1.1
     # via libsemigroups_pybind11 (pyproject.toml)
 pyyaml==6.0.3
     # via pybtex

--- a/uv.lock
+++ b/uv.lock
@@ -405,7 +405,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'docs'", specifier = ">=4.14.2" },
     { name = "graphviz", specifier = ">=0.21" },
     { name = "numpy", specifier = ">=2.2.6" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.2" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.1.1" },
     { name = "sphinx", marker = "python_full_version >= '3.11' and extra == 'docs'", specifier = ">=8.2" },
     { name = "sphinx", marker = "python_full_version < '3.11' and extra == 'docs'", specifier = ">=8.1.3" },
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5.2" },
@@ -797,7 +797,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -807,9 +807,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update pytest from 8.4.2 to 9.1.1 to address [Dependabot alert #38](https://github.com/libsemigroups/libsemigroups_pybind11/security/dependabot/38), concerning insecure temporary-directory handling ([CVE-2025-71176](https://github.com/advisories/GHSA-6w46-j5rx-g56g)). Raise the `test` extra's minimum in `pyproject.toml` and update the pins in `requirements.txt` and `uv.lock`, so both pip and uv installations select a patched version.

The security fix first shipped in [pytest 9.0.3](https://github.com/pytest-dev/pytest/releases/tag/9.0.3). Version 9.1.1 also includes the [fix for `--strict-markers` and `--strict-config` supplied through `addopts`](https://docs.pytest.org/en/stable/changelog.html#pytest-9-1-0-2026-06-13), which this repository uses. Python 3.10+ remains supported. No unrelated dependency versions change.

Validation, using a temporary Python 3.13 environment with the repository's Python sources and existing compiled extension:

- `uv lock --check --offline` passed, and a structural comparison confirmed only pytest and its project requirement changed in the lockfile.
- `uv sync --locked --all-extras --no-install-project --python /opt/homebrew/bin/python3.13` succeeded.
- `python -m pytest -m quick -q -o verbosity_test_cases=0`: 91 passed, 641 deselected.
- `python -m pytest -m 'not standard and not extreme' -q -o verbosity_test_cases=0`: all 732 collected tests passed.
- Both pre-commit hook stages ran on the three changed files: codespell passed; other hooks skipped because no applicable files changed.
- No C++ rebuild or documentation build was performed for this dependency-only change.

AI disclosure: OpenAI Codex investigated the alert, prepared the dependency update and PR description, and ran the validation checks.