### PR TITLE
Fix inherited Reporter methods on Runner subclasses

### DIFF
--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -363,8 +363,12 @@ run at the outermost level.
   }  // init_reporter
 
   void init_runner(py::module& m) {
+    // Runner is polymorphic, but Reporter is not, so the Reporter base can
+    // have a nonzero offset. Force pybind11 to adjust base pointers so that
+    // inherited Reporter methods access the correct memory.
     py::class_<Runner, Reporter> thing(m,
                                        "Runner",
+                                       py::multiple_inheritance(),
                                        R"pbdoc(
 Abstract class for derived [#sortof]_ classes that run an algorithm.
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -12,7 +12,15 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from libsemigroups_pybind11 import Reporter
+from libsemigroups_pybind11 import (
+    FroidurePin,
+    KnuthBendix,
+    Presentation,
+    Reporter,
+    ToddCoxeter,
+    Transf,
+    congruence_kind,
+)
 
 
 def test_reporter_000():
@@ -44,3 +52,65 @@ def test_reporter_000():
     assert s.report_every() == timedelta(seconds=1)
 
     assert s.report_every() == timedelta(seconds=1)
+
+
+@pytest.fixture(
+    name="reporter",
+    params=["Reporter", "FroidurePin", "ToddCoxeter", "KnuthBendixSet", "KnuthBendixTrie"],
+)
+def make_reporter(request):
+    """Return a reporter, including algorithms with inherited reporting methods."""
+    if request.param == "Reporter":
+        return Reporter()
+    if request.param == "FroidurePin":
+        return FroidurePin(Transf([1, 0]))
+    if request.param == "ToddCoxeter":
+        return ToddCoxeter(congruence_kind.twosided, Presentation("ab"))
+    return KnuthBendix(
+        congruence_kind.twosided,
+        Presentation("ab"),
+        rewriting_system=request.param.removeprefix("KnuthBendix"),
+    )
+
+
+@pytest.mark.quick
+def test_reporter_inherited_report_every(reporter):
+    """Inherited reporting methods must access the Reporter base subobject."""
+    assert reporter.report_every() == timedelta(seconds=1)
+    reporter.report_every(timedelta(seconds=2))
+    assert reporter.report_every() == timedelta(seconds=2)
+
+
+@pytest.mark.quick
+def test_reporter_inherited_report_prefix(reporter):
+    """Both prefix overloads must access the correct reporting prefix."""
+    expected = "" if isinstance(reporter, Reporter) else type(reporter).__name__
+    assert reporter.report_prefix() == expected
+    for prefix in ("a report prefix longer than a small string buffer", "foo", ""):
+        reporter.report_prefix(prefix)
+        assert reporter.report_prefix() == prefix
+
+
+@pytest.mark.quick
+def test_reporter_inherited_reset_last_report(reporter):
+    """Resetting the last report must preserve the start time."""
+    start = reporter.start_time()
+    before = datetime.now()
+    reporter.reset_last_report()
+    with pytest.deprecated_call():
+        last_report = reporter.last_report()
+    assert before <= last_report <= datetime.now()
+    assert abs(reporter.start_time() - start) < timedelta(milliseconds=1)
+
+
+@pytest.mark.quick
+def test_reporter_inherited_reset_start_time(reporter):
+    """Resetting the start time must also reset the last report time."""
+    before = datetime.now()
+    reporter.reset_start_time()
+    start = reporter.start_time()
+    with pytest.deprecated_call():
+        last_report = reporter.last_report()
+    assert before <= start <= datetime.now()
+    # Each conversion from high_resolution_clock samples system_clock anew.
+    assert abs(last_report - start) < timedelta(milliseconds=1)


### PR DESCRIPTION
Inherited reporting methods on `Runner` subclasses can access the wrong memory, causing the crashes and incorrect reporting state described in #447. `Runner` is polymorphic and its non-polymorphic `Reporter` base can have a nonzero offset. Registering `Runner` with `py::multiple_inheritance()` makes pybind11 apply the required base-pointer adjustment.

Add 20 test cases covering reporting prefixes, intervals, and timer resets on `Reporter`, `FroidurePin`, `ToddCoxeter`, and both Knuth–Bendix rewriting systems. Existing public signatures and return types are preserved.

Fixes #447.

Validation on macOS with Python 3.13, pybind11 3.0.1, and libsemigroups 3.6.1-298-g906ffc2:

- Rebuilt the C++ extension and verified the tests imported it.
- `pytest tests/test_runner.py tests/test_knuth_bendix.py tests/test_todd_coxeter.py tests/test_froidure_pin.py -q`: 79 passed.
- `pytest -m quick -q`: 111 passed, 641 deselected.
- Both pre-commit and pre-push hook stages passed for the changed files.
- `make doc` completed without warnings, and `make doctest` passed 1,509 tests. Optional diagram regeneration was skipped after Inkscape crashed.

AI assistance: OpenAI Codex investigated the invalid casts, prepared the binding fix and regression tests, and ran validation.