### PR TITLE
build(deps): update requests to 2.33.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -884,9 +884,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update Requests from 2.32.5 to 2.33.0 in `uv.lock` to address [Dependabot alert #33](https://github.com/libsemigroups/libsemigroups_pybind11/security/dependabot/33) (CVE-2026-25645: insecure temporary file reuse in `extract_zipped_paths()`). `requirements.txt` already pins 2.33.0. Only the Requests version and distribution metadata change.

Validation:

- `uv lock --check --offline` and `git diff --check` passed.
- Installed the locked documentation dependencies in an isolated temporary environment; `uv pip check` passed.
- Temporary smoke checks passed for distinct extracted paths, preservation of preexisting files, existing/missing path handling, and Sphinx request preparation.
- Both pre-commit hook stages completed: codespell passed; other hooks had no applicable files.
- No C++ rebuild or full pytest/doctest run for this lockfile-only change.

AI assistance: OpenAI Codex investigated the alert, prepared the dependency update, and ran the validation checks.